### PR TITLE
Do not load models with invalid names

### DIFF
--- a/core/src/main/kotlin/kr/toxicity/model/manager/ModelManagerImpl.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/manager/ModelManagerImpl.kt
@@ -12,6 +12,7 @@ import kr.toxicity.model.api.manager.ConfigManager.PackType.ZIP
 import kr.toxicity.model.api.manager.ModelManager
 import kr.toxicity.model.api.manager.ReloadInfo
 import kr.toxicity.model.util.*
+import net.kyori.adventure.key.Key
 import org.bukkit.inventory.ItemStack
 import java.io.File
 import java.security.DigestOutputStream
@@ -130,6 +131,10 @@ object ModelManagerImpl : ModelManager, GlobalManagerImpl {
         if (ConfigManagerImpl.module().model()) {
             DATA_FOLDER.subFolder("models").forEachAllFolder {
                 if (it.extension == "bbmodel") {
+                    if (!Key.parseableValue(it.nameWithoutExtension)) {
+                        warn("Skipping model with invalid name: '${it.name}', it will not be loaded. Only a-z, 0-9, '-', '_' and '.' characters allowed.")
+                        return@forEachAllFolder
+                    }
                     val load = it.toModel()
                     load.buildImage().forEach { image ->
                         zipper.add(texturesPath, "${image.name}.png") {


### PR DESCRIPTION
Currently, there are multiple ways a `.bbmodel` file with an invalid name can break the plugin.

### 1. Spaces in file names
A model file with spaces in its name will be loaded, but cannot be used with the `/bettermodel spawn` command. This is because space characters are treated as argument separators.

Additionally, if there exists another file with the same name but with spaces replaced by underscores (`_`), it results in a name collision during loading.

### 2. Case-insensitive name collisions
On Windows (case-insensitive file systems), it’s not possible to have two files whose names differ only in capitalization, but on Linux and macOS, this is allowed, and it leads to name collisions during load when the plugin treats both names as equivalent internally.

### 3. Special characters in file names (`+`, `$`, `&`, etc.)
All unsupported special characters (other than `_`, `-`, and `.`) causes the resource pack to not be loaded properly by the client and as a result, all models glitch out and appear with the missing texture placeholder.
![2025-04-24_21 51 40](https://github.com/user-attachments/assets/329416dc-0624-40e7-82b5-63934fe475a7)

### Possible solution
This PR introduces a strict filename validation check:
Only lowercase alphanumeric characters (`a-z`, `0-9`), underscores (`_`), hyphens (`-`), and periods (`.`) are allowed in model names. Models with invalid names are skipped during loading and a warning is logged to inform users that the model was not loaded due to an invalid name.