### PR TITLE
Fix model name conflicts

### DIFF
--- a/api/src/main/java/kr/toxicity/model/api/util/PackUtil.java
+++ b/api/src/main/java/kr/toxicity/model/api/util/PackUtil.java
@@ -18,7 +18,7 @@ public final class PackUtil {
         throw new RuntimeException();
     }
 
-    private static final Pattern REPLACE_SOURCE = Pattern.compile("[ -]");
+    private static final Pattern REPLACE_SOURCE = Pattern.compile("[^a-z0-9_.]");
 
     public static @NotNull String toPackName(@NotNull String raw) {
         return REPLACE_SOURCE.matcher(raw.toLowerCase()).replaceAll("_");

--- a/core/src/main/kotlin/kr/toxicity/model/manager/ModelManagerImpl.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/manager/ModelManagerImpl.kt
@@ -126,11 +126,19 @@ object ModelManagerImpl : ModelManager, GlobalManagerImpl {
 
         renderMap.clear()
         val model = arrayListOf<ModelBlueprint>()
+        val modelNames = hashMapOf<String, String>() // Map of model name -> source file name
 
         if (ConfigManagerImpl.module().model()) {
             DATA_FOLDER.subFolder("models").forEachAllFolder {
                 if (it.extension == "bbmodel") {
                     val load = it.toModel()
+                    val existingFile = modelNames[load.name]
+                    if (existingFile != null) {
+                        // A model with the same name already exists from a different file
+                        warn("Duplicate model name '${load.name}'. Files '${existingFile}' and '${it.name}' result in the same name. '${it.name}' will not be loaded.")
+                        return@forEachAllFolder
+                    }
+                    modelNames[load.name] = it.name
                     load.buildImage().forEach { image ->
                         zipper.add(texturesPath, "${image.name}.png") {
                             image.image.toByteArray()


### PR DESCRIPTION
#### 1. Fix for Special Character Handling
Previously, when a model file was named with special characters other than `_`, `.`, or `-`, it caused problems when client tried to load the resource pack, leading to missing texture placeholders for all models. Additionally, attempting to spawn models using the `/bettermodel spawn <model>` command failed due to the restricted use of special characters in Minecraft commands.
Now, all special characters are correctly replaced with underscores (`_`).
![2025-04-24_21 51 40](https://github.com/user-attachments/assets/329416dc-0624-40e7-82b5-63934fe475a7)

#### 2. Fix for Name Collisions
On Linux and macOS, it's possible to have two files with the same name except for capitalization (e.g., `ModelName` and `modelname`) in the same folder, which caused frequent name collisions. I introduced a new check for name collisions, and if a duplicate name is detected, the user is warned and the model with the conflicting name is not loaded.