### PR TITLE
feat: New MythicMobs Mechanic and add new features

### DIFF
--- a/api/src/main/java/kr/toxicity/model/api/animation/AnimationIterator.java
+++ b/api/src/main/java/kr/toxicity/model/api/animation/AnimationIterator.java
@@ -148,6 +148,7 @@ public interface AnimationIterator extends Iterator<AnimationMovement> {
     final class HoldOnLast implements AnimationIterator {
         private final List<AnimationMovement> keyFrame;
         private int index = 0;
+        private boolean finished = false;
 
         @NotNull
         @Override
@@ -168,17 +169,27 @@ public interface AnimationIterator extends Iterator<AnimationMovement> {
         @Override
         public void clear() {
             index = 0;
+            finished = false;
         }
 
         @Override
         public boolean hasNext() {
-            return index < keyFrame.size();
+            return true; // Fixed: Always returns true to keep the animation "alive".
         }
 
         @Override
         @NotNull
         public AnimationMovement next() {
-            return (index < keyFrame.size()) ? keyFrame.get(index++) : keyFrame.getLast();
+            if (finished) {
+                var last = keyFrame.getLast();
+                // Returns the last frame with time 0 to maintain the state without causing a long delay.
+                return new AnimationMovement(0, last.transform(), last.scale(), last.rotation());
+            }
+            var nextFrame = keyFrame.get(index++);
+            if (index >= keyFrame.size()) {
+                finished = true; // Mark as finished entering the "hold" mode.
+            }
+            return nextFrame;
         }
 
         @NotNull

--- a/api/src/main/java/kr/toxicity/model/api/manager/PlayerManager.java
+++ b/api/src/main/java/kr/toxicity/model/api/manager/PlayerManager.java
@@ -1,5 +1,6 @@
 package kr.toxicity.model.api.manager;
 
+import kr.toxicity.model.api.animation.AnimationIterator;
 import kr.toxicity.model.api.data.renderer.ModelRenderer;
 import kr.toxicity.model.api.nms.PlayerChannelHandler;
 import org.bukkit.entity.Player;
@@ -36,6 +37,16 @@ public interface PlayerManager extends GlobalManager {
      * @param animation animation name
      */
     void animate(@NotNull Player player, @NotNull String model, @NotNull String animation);
+
+    /**
+     * Play's animation to this player with a specific loop type.
+     * @param player player
+     * @param model model name
+     * @param animation animation name
+     * @param loopType the loop type to use, or null to use the animation's default.
+     */
+    void animate(@NotNull Player player, @NotNull String model, @NotNull String animation, @Nullable AnimationIterator.Type loopType);
+
 
     /**
      * Gets all renderers for player animation.

--- a/core/src/main/kotlin/kr/toxicity/model/compatibility/mythicmobs/MythicMobsCompatibility.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/compatibility/mythicmobs/MythicMobsCompatibility.kt
@@ -44,6 +44,7 @@ class MythicMobsCompatibility : Compatibility {
             @EventHandler
             fun MythicMechanicLoadEvent.load() {
                 when (mechanicName.lowercase()) {
+                    "playlimbanim" -> register(PlayLimbAnimMechanic(config))
                     "model" -> register(ModelMechanic(config))
                     "state", "animation" -> register(StateMechanic(config))
                     "defaultstate", "defaultanimation" -> register(DefaultStateMechanic(config))

--- a/core/src/main/kotlin/kr/toxicity/model/compatibility/mythicmobs/mechanic/PlayLimbAnimMechanic.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/compatibility/mythicmobs/mechanic/PlayLimbAnimMechanic.kt
@@ -1,0 +1,73 @@
+package kr.toxicity.model.compatibility.mythicmobs.mechanic
+
+import io.lumine.mythic.api.adapters.AbstractEntity
+import io.lumine.mythic.api.config.MythicLineConfig
+import io.lumine.mythic.api.skills.ITargetedEntitySkill
+import io.lumine.mythic.api.skills.SkillMetadata
+import io.lumine.mythic.api.skills.SkillResult
+import io.lumine.mythic.bukkit.MythicBukkit
+import io.lumine.mythic.core.skills.SkillMechanic
+import kr.toxicity.model.api.BetterModel
+import kr.toxicity.model.api.animation.AnimationIterator
+import kr.toxicity.model.api.animation.AnimationModifier
+import kr.toxicity.model.api.tracker.EntityTracker
+import kr.toxicity.model.compatibility.mythicmobs.toPlaceholderBoolean
+import kr.toxicity.model.compatibility.mythicmobs.toPlaceholderFloat
+import kr.toxicity.model.compatibility.mythicmobs.toPlaceholderString
+import kr.toxicity.model.compatibility.mythicmobs.toPlaceholderArgs
+import org.bukkit.entity.Player
+import java.util.function.BooleanSupplier
+
+class PlayLimbAnimMechanic(mlc: MythicLineConfig) : SkillMechanic(MythicBukkit.inst().skillManager, null, "", mlc), ITargetedEntitySkill {
+
+    private val modelId = mlc.toPlaceholderString(arrayOf("model", "m"))
+    private val animationId = mlc.toPlaceholderString(arrayOf("animation", "anim", "a"))
+    private val speed = mlc.toPlaceholderFloat(arrayOf("speed", "sp"), 1.0f)
+    private val remove = mlc.toPlaceholderBoolean(arrayOf("remove", "r"), false)
+    private val mode = mlc.toPlaceholderString(arrayOf("mode", "loop"), "once")
+
+    override fun castAtEntity(data: SkillMetadata, target: AbstractEntity): SkillResult {
+        val targetPlayer = target.bukkitEntity as? Player ?: return SkillResult.CONDITION_FAILED
+        val args = toPlaceholderArgs(data, target)
+
+        val currentModelId = modelId(args) ?: return SkillResult.INVALID_CONFIG
+        val currentAnimationId = animationId(args) ?: if (!remove(args)) return SkillResult.INVALID_CONFIG else ""
+
+        if (remove(args)) {
+            val tracker = EntityTracker.tracker(targetPlayer.uniqueId)
+            if (tracker != null && tracker.name() == currentModelId) {
+                tracker.close()
+            }
+        } else {
+            val renderer = BetterModel.plugin().playerManager().limb(currentModelId)
+                ?: return SkillResult.CONDITION_FAILED.also {
+                    println("Error: Player not found'$currentModelId'")
+                }
+
+            EntityTracker.tracker(targetPlayer.uniqueId)?.close()
+            val newTracker = renderer.create(targetPlayer)
+            newTracker.spawnNearby()
+
+            val loopType = when (mode(args)?.lowercase()) {
+                "loop" -> AnimationIterator.Type.LOOP
+                "hold" -> AnimationIterator.Type.HOLD_ON_LAST
+                else -> AnimationIterator.Type.PLAY_ONCE
+            }
+
+            val predicate = BooleanSupplier { true }
+            val speedModifier = AnimationModifier.SpeedModifier(speed(args))
+            val modifier = AnimationModifier(predicate, 0, 0, loopType, speedModifier)
+
+            val onEndTask: Runnable = if (loopType == AnimationIterator.Type.PLAY_ONCE) {
+                Runnable { newTracker.close() }
+            } else {
+                Runnable {}
+            }
+
+            if (!newTracker.animate(currentAnimationId, modifier, onEndTask)) {
+                newTracker.close()
+            }
+        }
+        return SkillResult.SUCCESS
+    }
+}

--- a/core/src/main/kotlin/kr/toxicity/model/manager/PlayerManagerImpl.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/manager/PlayerManagerImpl.kt
@@ -1,5 +1,6 @@
 package kr.toxicity.model.manager
 
+import kr.toxicity.model.api.animation.AnimationIterator
 import kr.toxicity.model.api.animation.AnimationModifier
 import kr.toxicity.model.api.data.blueprint.BlueprintChildren.BlueprintGroup
 import kr.toxicity.model.api.data.blueprint.ModelBlueprint
@@ -77,13 +78,24 @@ object PlayerManagerImpl : PlayerManager, GlobalManagerImpl {
     override fun limb(name: String): ModelRenderer? = renderMap[name]
 
     override fun animate(player: Player, model: String, animation: String) {
+        animate(player, model, animation, null)
+    }
+
+    override fun animate(player: Player, model: String, animation: String, loopType: AnimationIterator.Type?) {
         renderMap[model]?.let {
             EntityTracker.tracker(player.uniqueId)?.close()
             val create = it.create(player)
             create.spawnNearby()
-            if (!create.animate(animation, AnimationModifier.DEFAULT) {
-                create.close()
-            }) create.close()
+            val modifier = AnimationModifier(
+                { true },
+                1,
+                0,
+                loopType,
+                1.0f
+            )
+            if (!create.animate(animation, modifier) {
+                    create.close()
+                }) create.close()
         }
     }
 

--- a/core/src/main/kotlin/kr/toxicity/model/manager/SkinManagerImpl.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/manager/SkinManagerImpl.kt
@@ -21,6 +21,8 @@ import net.jodah.expiringmap.ExpirationPolicy
 import net.jodah.expiringmap.ExpiringMap
 import org.bukkit.Bukkit
 import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import kr.toxicity.library.dynamicuv.UVByteBuilder
 import java.net.URI
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
@@ -32,7 +34,7 @@ import javax.imageio.ImageIO
 object SkinManagerImpl : SkinManager, GlobalManagerImpl {
 
     private const val DIV_FACTOR = 16F / 0.9375F
-    
+
     private var uvNamespace = UVNamespace(
         ConfigManagerImpl.namespace(),
         "player_limb"
@@ -584,9 +586,14 @@ object SkinManagerImpl : SkinManager, GlobalManagerImpl {
         SLIM_LEFT_FOREARM.write(block)
         SLIM_RIGHT_ARM.write(block)
         SLIM_RIGHT_FOREARM.write(block)
-        UVByteBuilder.emptyImage(uvNamespace, "one_pixel").run {
-            block(path()) {
-                build()
+
+        // If an image is 1x1 or 3x3 idk, break all the mimap level of the game, and everything is going to be blurred and bad quality, so you have to use 16x16 or 32x32
+        val builder = UVByteBuilder.emptyImage(uvNamespace, "one_pixel")
+        block(builder.path()) {
+            val image = BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB)
+            ByteArrayOutputStream().use { buffer ->
+                ImageIO.write(image, "png", buffer)
+                buffer.toByteArray()
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
 minecraft_version=1.21.5
+kotlin.daemon.jvmargs=-Xmx4g


### PR DESCRIPTION
This commit introduces the 'playlimbanim' mechanic, adds more control over animations, and fixes key rendering and logic bugs.

- Adds the 'playlimbanim' mechanic for MythicMobs, allowing player animations to be triggered on targets via skills.
- Implements an optional 'loop_type' argument for the /bm play command, enabling direct control over the animation's loop mode.
- Corrects the 'HOLD_ON_LAST' animation logic to ensure it properly freezes on the final frame as intended.
- Fixes a rendering bug by changing the 'one_pixel.png' base texture to 16x16 to prevent mipmap issues.