### PR TITLE
Proposed resolution for incorrectly scheduled entity tracker

### DIFF
--- a/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/nms/v1_21_R5/NMSImpl.kt
+++ b/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/nms/v1_21_R5/NMSImpl.kt
@@ -193,13 +193,11 @@ class NMSImpl : NMS {
                     it.handle()
                 })
                 is ClientboundAddEntityPacket -> {
+                BetterModel.plugin().scheduler().task(player.location) {
                     id.toRegistry(
                         { if (EntityTrackerRegistry.hasModelData(it.bukkitEntity)) EntityTrackerRegistry.registry(it.bukkitEntity) else null },
                         { true }
-                    )?.let {
-                        BetterModel.plugin().scheduler().asyncTaskLater(1) {
-                            it.spawnIfMatched(player)
-                        }
+                    )?.spawnIfMatched(player)
                     }
                 }
                 is ClientboundRemoveEntitiesPacket -> {


### PR DESCRIPTION
If the user summons a boss, the user will be kicked on Folia and unable to join. From testing, this appeared to resolve said issue.

Example exception: https://mclo.gs/ZhyWf6w