### PR TITLE
Shade Adventure library to resolve classloading conflicts with Ignite

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 
+    compileOnly(libs.adventurePlatformBukkit)
+
     testCompileOnly(libs.lombok)
     testAnnotationProcessor(libs.lombok)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,8 @@ tasks {
         prefix("kr.toxicity.library")
         prefix("dev.jorel.commandapi")
         prefix("org.bstats")
+        relocate("net.kyori.adventure", "$groupString.shaded.net.kyori.adventure")
+        relocate("net.kyori.examination", "$groupString.shaded.net.kyori.examination")
     }
     build {
         finalizedBy(

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
         implementation(project(":nms:${it.name}", configuration = "reobf"))
     }
     implementation(libs.bundles.shadedLibrary) {
-        exclude("net.kyori")
+        //exclude("net.kyori")
         exclude("org.ow2.asm")
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,7 @@ molangCompiler = "gg.moonflower:molang-compiler:3.1.1.19"
 [bundles]
 library = [
     "semver4j",
-    "expiringMap",
-    "adventurePlatformBukkit"
+    "expiringMap"
 ]
 
 shadedLibrary = [
@@ -29,7 +28,8 @@ shadedLibrary = [
     "bStats",
     "dynamicUV",
     "sharedPackets",
-    "molangCompiler"
+    "molangCompiler",
+    "adventurePlatformBukkit"
 ]
 
 [plugins]


### PR DESCRIPTION
Hello! This pull request fixes a compatibility issue with servers running the Ignite framework. https://github.com/vectrix-space/ignite

Right now, BetterModel crashes when used with Ignite because of a classloading conflict. The plugin includes a non-shaded version of adventure-platform-bukkit, which conflicts with the Adventure API from the Paper server. This happens when Ignite changes the runtime environment.

I’m not sure if you will accept this, but ModelEngine has the same issues. Adding Ignite support would give you another feature for your comparison list.

I have tested the plugin loading on Paper, Ignite (with Paper), Craftbukkit, and Spigot with these changes, so I don’t think anything will break.