### PR TITLE
fix: Fixed UV mappings for the right forearm of the player skin in SkinManagerImpl.kt

### DIFF
--- a/core/src/main/kotlin/kr/toxicity/model/manager/SkinManagerImpl.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/manager/SkinManagerImpl.kt
@@ -404,10 +404,10 @@ object SkinManagerImpl : SkinManager, GlobalManager {
             UVSpace(4, 6, 4),
             UVElement.ColorType.RGB,
             mapOf(
-                UVFace.NORTH to UVPos(44, 24),
-                UVFace.SOUTH to UVPos(52, 24),
-                UVFace.EAST to UVPos(40, 24),
-                UVFace.WEST to UVPos(48, 24),
+                UVFace.NORTH to UVPos(44, 26),
+                UVFace.SOUTH to UVPos(52, 26),
+                UVFace.EAST to UVPos(40, 26),
+                UVFace.WEST to UVPos(48, 26),
                 UVFace.DOWN to UVPos(48, 16)
             )
         )
@@ -418,10 +418,10 @@ object SkinManagerImpl : SkinManager, GlobalManager {
             UVSpace(4, 6, 4),
             UVElement.ColorType.ARGB,
             mapOf(
-                UVFace.NORTH to UVPos(44, 24 + 16),
-                UVFace.SOUTH to UVPos(52, 24 + 16),
-                UVFace.EAST to UVPos(40, 24 + 16),
-                UVFace.WEST to UVPos(48, 24 + 16),
+                UVFace.NORTH to UVPos(44, 26 + 16),
+                UVFace.SOUTH to UVPos(52, 26 + 16),
+                UVFace.EAST to UVPos(40, 26 + 16),
+                UVFace.WEST to UVPos(48, 26 + 16),
                 UVFace.DOWN to UVPos(48, 16 + 16)
             )
         )
@@ -532,10 +532,10 @@ object SkinManagerImpl : SkinManager, GlobalManager {
             UVSpace(3, 6, 4),
             UVElement.ColorType.RGB,
             mapOf(
-                UVFace.NORTH to UVPos(44, 24),
-                UVFace.SOUTH to UVPos(51, 24),
-                UVFace.EAST to UVPos(40, 24),
-                UVFace.WEST to UVPos(47, 24),
+                UVFace.NORTH to UVPos(44, 26),
+                UVFace.SOUTH to UVPos(51, 26),
+                UVFace.EAST to UVPos(40, 26),
+                UVFace.WEST to UVPos(47, 26),
                 UVFace.DOWN to UVPos(47, 16)
             )
         )
@@ -546,10 +546,10 @@ object SkinManagerImpl : SkinManager, GlobalManager {
             UVSpace(3, 6, 4),
             UVElement.ColorType.ARGB,
             mapOf(
-                UVFace.NORTH to UVPos(44, 24 + 16),
-                UVFace.SOUTH to UVPos(51, 24 + 16),
-                UVFace.EAST to UVPos(40, 24 + 16),
-                UVFace.WEST to UVPos(47, 24 + 16),
+                UVFace.NORTH to UVPos(44, 26 + 16),
+                UVFace.SOUTH to UVPos(51, 26 + 16),
+                UVFace.EAST to UVPos(40, 26 + 16),
+                UVFace.WEST to UVPos(47, 26 + 16),
                 UVFace.DOWN to UVPos(47, 16 + 16)
             )
         )


### PR DESCRIPTION
There is an issue with right forearm textures in player models. Their UV mappings in SkingManagerImpl.kt has wrong Y coordinates and upper 2 pixels of the right forearm was identical to the 2 pixels at the bottom of the right arm (you can see this on the image. There is orange highlight at the right forearm of the model and at the corresponding part of my skin).

I fixed uv mappings for the both RIGHT_FOREARM and SLIM_RIGHT_FOREARM. Sadly, I didn't quite understand your repository structure so I wasn't able to build and test my version but I still made this PR for you to look and consider.

<img width="1000" height="523" alt="Model Bug" src="https://github.com/user-attachments/assets/51c72d17-97ca-4f2f-a9f6-053ca8fedaaa" />
