### PR TITLE
fix: mount controller strafing

### DIFF
--- a/api/src/main/java/kr/toxicity/model/api/mount/MountControllers.java
+++ b/api/src/main/java/kr/toxicity/model/api/mount/MountControllers.java
@@ -52,12 +52,13 @@ public enum MountControllers implements MountController {
         @NotNull
         @Override
         public Vector3f move(@NotNull Player player, @NotNull LivingEntity entity, @NotNull Vector3f input, @NotNull Vector3f travelVector) {
+            input.normalize();
             input.y = 0;
             input.x = input.x * 0.5F;
             if (input.z <= 0.0F) {
                 input.z *= 0.25F;
             }
-            return input.normalize();
+            return input;
         }
     },
     /**
@@ -67,11 +68,12 @@ public enum MountControllers implements MountController {
         @NotNull
         @Override
         public Vector3f move(@NotNull Player player, @NotNull LivingEntity entity, @NotNull Vector3f input, @NotNull Vector3f travelVector) {
+            input.normalize();
             input.x = input.x * 0.5F;
             if (input.z <= 0.0F) {
                 input.z *= 0.25F;
             }
-            return input.normalize();
+            return input;
         }
 
         @Override


### PR DESCRIPTION
### Summary
Fixed an issue where the movement speed exceeded the intended value when pressing forward and lateral keys simultaneously in the Mount Controller.

### Details
- **Root Cause**: Missing normalization of input values caused the velocity magnitude to reach approximately `1.4` during diagonal movement due to vector summation.
- **Solution**: Applied vector normalization to ensure uniform speed across all input directions.
- **Result**: Confirmed that the speed is now calculated normally, minimizing the margin of error from the target value (1.0).

----

### 요약
Mount Controller 사용 중 전진과 좌우 키를 동시에 입력했을 때 이동 속도가 의도보다 빠르게 산출되는 문제를 수정했습니다.

### 상세 내용
- **문제 원인**: 입력값에 대한 정규화(Normalization) 처리가 누락되어, 대각선 방향 입력 시 벡터 합산으로 인해 속도 값이 약 1.4까지 증가하는 현상이 발생했습니다.
- **해결 방법**: 입력 벡터에 정규화 로직을 도입하여 방향에 관계없이 일정한 속도를 유지하도록 개선했습니다.
- **결과**: 수정 후 속도 값이 정상적으로 산출되는 것을 확인하였으며, 의도한 속도(1.0)와의 오차를 최소화했습니다.