### PR TITLE
(Suggestion) refactor: replace constructors with static factory methods for fabric classes

### DIFF
--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricAdapter.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricAdapter.java
@@ -41,7 +41,7 @@ public final class FabricAdapter implements PlatformAdapter {
      * @since 2.0.0
      */
     public static @NotNull PlatformEntity adapt(@NotNull Entity entity) {
-        return new FabricEntity(entity);
+        return FabricEntity.of(entity);
     }
 
     /**
@@ -52,7 +52,7 @@ public final class FabricAdapter implements PlatformAdapter {
      * @since 2.0.0
      */
     public static @NotNull PlatformLivingEntity adapt(@NotNull LivingEntity livingEntity) {
-        return new FabricLivingEntity(livingEntity);
+        return FabricLivingEntity.of(livingEntity);
     }
 
     /**
@@ -63,7 +63,7 @@ public final class FabricAdapter implements PlatformAdapter {
      * @since 2.0.0
      */
     public static @NotNull PlatformPlayer adapt(@NotNull ServerPlayerConnection connection) {
-        return new FabricPlayer(connection);
+        return FabricPlayer.of(connection);
     }
 
     /**
@@ -85,7 +85,7 @@ public final class FabricAdapter implements PlatformAdapter {
      * @since 2.0.0
      */
     public static @NotNull PlatformOfflinePlayer adapt(@NotNull UUID uuid) {
-        return new FabricOfflinePlayer(uuid, null);
+        return FabricOfflinePlayer.of(uuid, null);
     }
 
     /**
@@ -96,7 +96,7 @@ public final class FabricAdapter implements PlatformAdapter {
      * @since 2.0.0
      */
     public static @NotNull PlatformOfflinePlayer adapt(@NotNull GameProfile profile) {
-        return new FabricOfflinePlayer(profile.id(), profile.name());
+        return FabricOfflinePlayer.of(profile.id(), profile.name());
     }
 
     /**
@@ -107,7 +107,7 @@ public final class FabricAdapter implements PlatformAdapter {
      * @since 2.0.0
      */
     public static @NotNull PlatformItemStack adapt(@NotNull ItemStack itemStack) {
-        return new FabricItemStack(itemStack);
+        return FabricItemStack.of(itemStack);
     }
 
     /**
@@ -118,7 +118,7 @@ public final class FabricAdapter implements PlatformAdapter {
      * @since 2.0.0
      */
     public static @NotNull PlatformWorld adapt(@NotNull Level world) {
-        return new FabricWorld(world);
+        return FabricWorld.of(world);
     }
 
     @Override
@@ -155,7 +155,7 @@ public final class FabricAdapter implements PlatformAdapter {
 
     @Override
     public @NotNull PlatformLocation zero() {
-        return new FabricLocation(null, 0, 0, 0, 0, 0);
+        return FabricLocation.of(null, 0, 0, 0);
     }
 
     private @NotNull MinecraftServer server() {

--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricEntity.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricEntity.java
@@ -9,6 +9,7 @@ package kr.toxicity.model.api.fabric.platform;
 import kr.toxicity.model.api.platform.PlatformEntity;
 import kr.toxicity.model.api.platform.PlatformLocation;
 import net.minecraft.world.entity.Entity;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -20,6 +21,21 @@ import java.util.UUID;
  * @since 2.0.0
  */
 public record FabricEntity(@NotNull Entity source) implements PlatformEntity {
+    @ApiStatus.Internal
+    public FabricEntity {
+    }
+
+    /**
+     * Creates a FabricEntity from the source.
+     *
+     * @param source the source entity
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricEntity of(@NotNull Entity source) {
+        return new FabricEntity(source);
+    }
+
     @Override
     public @NotNull UUID uuid() {
         return source.getUUID();

--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricItemStack.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricItemStack.java
@@ -12,6 +12,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomModelData;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,6 +25,21 @@ import java.util.List;
  * @since 2.0.0
  */
 public record FabricItemStack(@NotNull ItemStack source) implements PlatformItemStack {
+    @ApiStatus.Internal
+    public FabricItemStack {
+    }
+
+    /**
+     * Creates a FabricItemStack from the source.
+     *
+     * @param source the source item stack
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricItemStack of(@NotNull ItemStack source) {
+        return new FabricItemStack(source);
+    }
+
     @Override
     public boolean isAir() {
         return source.isEmpty();

--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricLivingEntity.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricLivingEntity.java
@@ -9,6 +9,7 @@ package kr.toxicity.model.api.fabric.platform;
 import kr.toxicity.model.api.platform.PlatformLivingEntity;
 import kr.toxicity.model.api.platform.PlatformLocation;
 import net.minecraft.world.entity.LivingEntity;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -20,6 +21,21 @@ import java.util.UUID;
  * @since 2.0.0
  */
 public record FabricLivingEntity(@NotNull LivingEntity source) implements PlatformLivingEntity {
+    @ApiStatus.Internal
+    public FabricLivingEntity {
+    }
+
+    /**
+     * Creates a FabricLivingEntity from the source.
+     *
+     * @param source the source living entity
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricLivingEntity of(@NotNull LivingEntity source) {
+        return new FabricLivingEntity(source);
+    }
+
     @Override
     public @NotNull UUID uuid() {
         return source.getUUID();

--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricLocation.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricLocation.java
@@ -14,6 +14,8 @@ import kr.toxicity.model.api.platform.PlatformWorld;
 import kr.toxicity.model.api.scheduler.ModelTask;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,6 +31,94 @@ import org.jetbrains.annotations.Nullable;
  * @since 2.0.0
  */
 public record FabricLocation(@Nullable Level level, double x, double y, double z, float pitch, float yaw) implements PlatformLocation {
+    @ApiStatus.Internal
+    public FabricLocation {
+    }
+
+    /**
+     * Creates a FabricLocation from the coordinates.
+     *
+     * @param level the NMS level
+     * @param x     the x coordinate
+     * @param y     the y coordinate
+     * @param z     the z coordinate
+     * @param pitch the pitch
+     * @param yaw   the yaw
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricLocation of(@Nullable Level level, double x, double y, double z, float pitch, float yaw) {
+        return new FabricLocation(
+            level,
+            x,
+            y,
+            z,
+            pitch,
+            yaw
+        );
+    }
+
+    /**
+     * Creates a FabricLocation from the coordinates with zero pitch and yaw.
+     *
+     * @param level the NMS level
+     * @param x     the x coordinate
+     * @param y     the y coordinate
+     * @param z     the z coordinate
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricLocation of(@Nullable Level level, double x, double y, double z) {
+        return new FabricLocation(
+            level,
+            x,
+            y,
+            z,
+            0.0f,
+            0.0f
+        );
+    }
+
+    /**
+     * Creates a FabricLocation from the position vector.
+     *
+     * @param level    the NMS level
+     * @param position the position vector
+     * @param pitch    the pitch
+     * @param yaw      the yaw
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricLocation of(@Nullable Level level, Vec3 position, float pitch, float yaw) {
+        return new FabricLocation(
+            level,
+            position.x,
+            position.y,
+            position.z,
+            pitch,
+            yaw
+        );
+    }
+
+    /**
+     * Creates a FabricLocation from the position vector with zero pitch and yaw.
+     *
+     * @param level    the NMS level
+     * @param position the position vector
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricLocation of(@Nullable Level level, Vec3 position) {
+        return new FabricLocation(
+            level,
+            position.x,
+            position.y,
+            position.z,
+            0.0f,
+            0.0f
+        );
+    }
+
     /**
      * Creates a FabricLocation from an entity's position.
      *

--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricOfflinePlayer.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricOfflinePlayer.java
@@ -7,6 +7,7 @@
 package kr.toxicity.model.api.fabric.platform;
 
 import kr.toxicity.model.api.platform.PlatformOfflinePlayer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,4 +21,19 @@ import java.util.UUID;
  * @since 2.0.0
  */
 public record FabricOfflinePlayer(@NotNull UUID uuid, @Nullable String name) implements PlatformOfflinePlayer {
+    @ApiStatus.Internal
+    public FabricOfflinePlayer {
+    }
+
+    /**
+     * Creates a FabricOfflinePlayer from the UUID and name.
+     *
+     * @param uuid the player uuid
+     * @param name the player name
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricOfflinePlayer of(@NotNull UUID uuid, @Nullable String name) {
+        return new FabricOfflinePlayer(uuid, name);
+    }
 }

--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricPlayer.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricPlayer.java
@@ -9,6 +9,7 @@ package kr.toxicity.model.api.fabric.platform;
 import kr.toxicity.model.api.platform.PlatformLocation;
 import kr.toxicity.model.api.platform.PlatformPlayer;
 import net.minecraft.server.network.ServerPlayerConnection;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -20,6 +21,21 @@ import java.util.UUID;
  * @since 2.0.0
  */
 public record FabricPlayer(@NotNull ServerPlayerConnection source) implements PlatformPlayer {
+    @ApiStatus.Internal
+    public FabricPlayer {
+    }
+
+    /**
+     * Creates a FabricPlayer from the source.
+     *
+     * @param source the source player connection
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricPlayer of(@NotNull ServerPlayerConnection source) {
+        return new FabricPlayer(source);
+    }
+
     @Override
     public @NotNull UUID uuid() {
         return source.getPlayer().getUUID();

--- a/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricWorld.java
+++ b/platform/fabric/src/main/java/kr/toxicity/model/api/fabric/platform/FabricWorld.java
@@ -8,6 +8,7 @@ package kr.toxicity.model.api.fabric.platform;
 
 import kr.toxicity.model.api.platform.PlatformWorld;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -17,4 +18,18 @@ import org.jetbrains.annotations.NotNull;
  * @since 2.0.0
  */
 public record FabricWorld(@NotNull Level level) implements PlatformWorld {
+    @ApiStatus.Internal
+    public FabricWorld {
+    }
+
+    /**
+     * Creates a FabricWorld from the level.
+     *
+     * @param level the source level
+     * @return the instance
+     * @since 2.0.0
+     */
+    public static @NotNull FabricWorld of(@NotNull Level level) {
+        return new FabricWorld(level);
+    }
 }

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/command/Commands.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/command/Commands.kt
@@ -289,7 +289,7 @@ private fun test(context: CommandContext<Audience>) {
     val location = context.nullable<Coordinates>("location")?.position() ?: player.position()
         .add(Vec3(0.0, 0.0, 10.0).yRot(-Math.toRadians(player.yRot.toDouble()).toFloat()))
 
-    model.create(FabricLocation(
+    model.create(FabricLocation.of(
         player.level(),
         location.x,
         location.y,

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/HitBoxEntityImpl.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/HitBoxEntityImpl.kt
@@ -106,7 +106,7 @@ class HitBoxEntityImpl(
 
     override fun uuid(): UUID = uuid
 
-    override fun source(): PlatformEntity = FabricEntity(delegate)
+    override fun source(): PlatformEntity = FabricEntity.of(delegate)
 
     override fun positionSource(): RenderedBone = bone
 
@@ -164,7 +164,7 @@ class HitBoxEntityImpl(
 
         interaction.passengers.forEach { passenger ->
             passenger.stopRiding()
-            listener.dismount(this, FabricEntity(passenger))
+            listener.dismount(this, FabricEntity.of(passenger))
         }
 
         forceDismount = false
@@ -295,7 +295,7 @@ class HitBoxEntityImpl(
                 MountController.MoveType.DEFAULT
             },
             player.connection.wrap(),
-            FabricLivingEntity(delegate as LivingEntity),
+            FabricLivingEntity.of(delegate as LivingEntity),
             Vector3f(
                 player.xMovement(),
                 player.yMovement(),

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/world/damagesource/ModelDamageSourceImpl.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/world/damagesource/ModelDamageSourceImpl.kt
@@ -14,13 +14,13 @@ import kr.toxicity.model.api.platform.PlatformLocation
 import net.minecraft.world.damagesource.DamageSource
 
 class ModelDamageSourceImpl(private val source: DamageSource) : ModelDamageSource {
-    override fun getCausingEntity(): PlatformEntity? = source.entity?.let { FabricEntity(it) }
+    override fun getCausingEntity(): PlatformEntity? = source.entity?.let { FabricEntity.of(it) }
 
-    override fun getDirectEntity(): PlatformEntity? = source.directEntity?.let { FabricEntity(it) }
+    override fun getDirectEntity(): PlatformEntity? = source.directEntity?.let { FabricEntity.of(it) }
 
     override fun getDamageLocation(): PlatformLocation? {
         return source.sourcePositionRaw()?.let { pos ->
-            FabricLocation(
+            FabricLocation.of(
                 source.entity?.level(),
                 pos.x, pos.y, pos.z,
                 0f, 0f
@@ -30,7 +30,7 @@ class ModelDamageSourceImpl(private val source: DamageSource) : ModelDamageSourc
 
     override fun getSourceLocation(): PlatformLocation? {
         return source.sourcePosition?.let { pos ->
-            FabricLocation(
+            FabricLocation.of(
                 source.entity?.level(),
                 pos.x, pos.y, pos.z,
                 0f, 0f

--- a/platform/fabric/src/testmod/kotlin/kr/toxicity/model/test/RollTest.kt
+++ b/platform/fabric/src/testmod/kotlin/kr/toxicity/model/test/RollTest.kt
@@ -84,7 +84,7 @@ class RollTest : ModInitializer {
 
         val yaw = player.lastClientInput.toYaw()
         val tracker = renderer.getOrCreate(
-            FabricPlayer(player.connection),
+            FabricPlayer.of(player.connection),
             TrackerModifier.DEFAULT
         ) { tracker ->
             tracker.rotation {


### PR DESCRIPTION
We could consider using `@Deprecated` instead of `@ApiStatus.Internal`.