### PR TITLE
fix: Folia thread-safety for rotation reads and death model cleanup

### DIFF
--- a/api/src/main/java/kr/toxicity/model/api/tracker/EntityBodyRotator.java
+++ b/api/src/main/java/kr/toxicity/model/api/tracker/EntityBodyRotator.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import kr.toxicity.model.api.entity.BaseEntity;
 import kr.toxicity.model.api.util.FunctionUtil;
 import kr.toxicity.model.api.util.MathUtil;
+import kr.toxicity.model.api.util.function.FloatSupplier;
 import kr.toxicity.model.api.util.lazy.LazyFloatProvider;
 import lombok.AllArgsConstructor;
 import lombok.Setter;
@@ -19,6 +20,7 @@ import org.joml.Vector3f;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -40,6 +42,11 @@ public final class EntityBodyRotator {
     private final LazyFloatProvider provider;
     private final Supplier<Quaternionf> headSupplier;
     private final Supplier<ModelRotation> bodySupplier;
+    private final FloatSupplier pitchSupplier;
+    private final FloatSupplier bodyYawSupplier;
+    private final FloatSupplier headYawSupplier;
+    private final BooleanSupplier walkSupplier;
+    private final FloatSupplier yawSupplier;
     private final AtomicBoolean rotationLock = new AtomicBoolean();
     private int tick;
     private final Quaternionf headRotation = new Quaternionf();
@@ -73,20 +80,25 @@ public final class EntityBodyRotator {
     EntityBodyRotator(@NotNull EntityTrackerRegistry registry) {
         this.registry = registry;
         this.entity = registry.entity();
+        this.pitchSupplier = FunctionUtil.throttleTickFloat(entity::pitch);
+        this.bodyYawSupplier = FunctionUtil.throttleTickFloat(entity::bodyYaw);
+        this.headYawSupplier = FunctionUtil.throttleTickFloat(entity::headYaw);
+        this.walkSupplier = FunctionUtil.throttleTickBoolean(entity::onWalk);
+        this.yawSupplier = FunctionUtil.throttleTickFloat(entity::yaw);
         this.rotation = new ModelRotation(
-            entity.pitch(),
-            entity.yaw()
+            pitchSupplier.getAsFloat(),
+            yawSupplier.getAsFloat()
         );
-        this.provider = new LazyFloatProvider(entity.yaw(), () -> rotationDuration * MathUtil.MINECRAFT_TICK_MILLS);
+        this.provider = new LazyFloatProvider(yawSupplier.getAsFloat(), () -> rotationDuration * MathUtil.MINECRAFT_TICK_MILLS);
         var vector = new Vector3f();
         var vectorSupplier = LazyFloatProvider.ofVector(() -> 3 * MathUtil.MINECRAFT_TICK_MILLS, () -> vector.set(
-            clampHead(entity.pitch()),
-            clampHead(wrapDegrees(bodyRotation().y() - entity.headYaw())),
+            clampHead(pitchSupplier.getAsFloat()),
+            clampHead(wrapDegrees(bodyRotation().y() - headYawSupplier.getAsFloat())),
             0
         ));
         headSupplier = FunctionUtil.throttleTick(Tracker.TRACKER_TICK_INTERVAL, () -> MathUtil.toQuaternion(vectorSupplier.get(), headRotation));
         bodySupplier = FunctionUtil.throttleTick(() -> new ModelRotation(
-            entity.pitch(),
+            pitchSupplier.getAsFloat(),
             bodyRotation0()
         ));
         reset();
@@ -116,16 +128,16 @@ public final class EntityBodyRotator {
     }
 
     private float bodyRotation0() {
-        if (playerMode) return entity.bodyYaw();
-        if (registry.hasControllingPassenger()) return entity.yaw();
-        if (entity.onWalk()) {
+        if (playerMode) return bodyYawSupplier.getAsFloat();
+        if (registry.hasControllingPassenger()) return yawSupplier.getAsFloat();
+        if (walkSupplier.getAsBoolean()) {
             tick = rotationDelay;
             return stableBodyYaw();
-        } else if (MathUtil.isSimilar(entity.headYaw(), rotation.y(), DEGREE_EPSILON)) {
+        } else if (MathUtil.isSimilar(headYawSupplier.getAsFloat(), rotation.y(), DEGREE_EPSILON)) {
             tick = 0;
-            return entity.headYaw();
+            return headYawSupplier.getAsFloat();
         } else if (++tick > rotationDelay) {
-            var headYaw = entity.headYaw();
+            var headYaw = headYawSupplier.getAsFloat();
             var providedYaw = provider.updateAndGet(headYaw);
             return wrapDegrees(clampBody(providedYaw, headYaw));
         }
@@ -135,7 +147,7 @@ public final class EntityBodyRotator {
 
     private float stableBodyYaw() {
         var bodyYaw = rotation.y();
-        var yaw = entity.yaw();
+        var yaw = yawSupplier.getAsFloat();
         var minStable = yaw - stable;
         var maxStable = yaw + stable;
         return wrapDegrees(Math.clamp(bodyYaw, Math.min(minStable, maxStable), Math.max(minStable, maxStable)));

--- a/api/src/main/java/kr/toxicity/model/api/tracker/EntityTracker.java
+++ b/api/src/main/java/kr/toxicity/model/api/tracker/EntityTracker.java
@@ -170,7 +170,7 @@ public class EntityTracker extends Tracker {
      * @since 1.15.2
      */
     public void updateBaseEntity() {
-        BetterModel.platform().scheduler().asyncTaskLater(1, () -> {
+        registry.entity().platform().taskLater(1, () -> {
             updateBaseEntity0();
             forceUpdate(true);
         });

--- a/api/src/main/java/kr/toxicity/model/api/tracker/EntityTrackerRegistry.java
+++ b/api/src/main/java/kr/toxicity/model/api/tracker/EntityTrackerRegistry.java
@@ -404,7 +404,11 @@ public final class EntityTrackerRegistry {
      */
     public void despawn() {
         for (EntityTracker value : trackers()) {
-            if (!value.forRemoval()) value.despawn();
+            if (value.forRemoval()) {
+                if (!value.isClosed()) value.close(Tracker.CloseReason.DESPAWN);
+            } else {
+                value.despawn();
+            }
         }
         viewedPlayerMap.clear();
     }

--- a/core/bukkit-core/src/main/kotlin/kr/toxicity/model/bukkit/manager/EntityManager.kt
+++ b/core/bukkit-core/src/main/kotlin/kr/toxicity/model/bukkit/manager/EntityManager.kt
@@ -120,8 +120,12 @@ object EntityManager : GlobalManager {
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         fun EntityDeathEvent.death() { //Death
             entity.forEachTracker {
-                if (it.animate("death", AnimationModifier.DEFAULT_WITH_PLAY_ONCE) { it.close() }) {
-                    it.forRemoval(true)
+                it.forRemoval(true)
+                if (!it.animate("death", AnimationModifier.DEFAULT_WITH_PLAY_ONCE) { it.close() }) {
+                    // No death animation — schedule forced close after vanilla death sequence (20 ticks)
+                    it.sourceEntity().platform().taskLater(20) {
+                        if (!it.isClosed) it.close()
+                    }
                 }
             }
         }

--- a/core/bukkit-core/src/main/kotlin/kr/toxicity/model/bukkit/manager/EntityManager.kt
+++ b/core/bukkit-core/src/main/kotlin/kr/toxicity/model/bukkit/manager/EntityManager.kt
@@ -121,12 +121,7 @@ object EntityManager : GlobalManager {
         fun EntityDeathEvent.death() { //Death
             entity.forEachTracker {
                 it.forRemoval(true)
-                if (!it.animate("death", AnimationModifier.DEFAULT_WITH_PLAY_ONCE) { it.close() }) {
-                    // No death animation — schedule forced close after vanilla death sequence (20 ticks)
-                    it.sourceEntity().platform().taskLater(20) {
-                        if (!it.isClosed) it.close()
-                    }
-                }
+                it.animate("death", AnimationModifier.DEFAULT_WITH_PLAY_ONCE) { it.close() }
             }
         }
         @EventHandler(priority = EventPriority.MONITOR)

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/manager/EntityManager.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/manager/EntityManager.kt
@@ -190,18 +190,11 @@ object EntityManager : GlobalManager {
         ServerLivingEntityEvents.AFTER_DEATH.register { entity, _ ->
             entity.eachTracker { tracker ->
                 tracker.forRemoval(true)
-                val animated = tracker.animate(
+                tracker.animate(
                     "death",
                     AnimationModifier.DEFAULT_WITH_PLAY_ONCE
                 ) {
                     tracker.close()
-                }
-
-                if (!animated) {
-                    // No death animation — schedule forced close after vanilla death sequence (20 ticks)
-                    tracker.sourceEntity().platform().taskLater(20) {
-                        if (!tracker.isClosed) tracker.close()
-                    }
                 }
             }
 

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/manager/EntityManager.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/manager/EntityManager.kt
@@ -189,6 +189,7 @@ object EntityManager : GlobalManager {
         // same as EntityDeathEvent, PlayerDeathEvent
         ServerLivingEntityEvents.AFTER_DEATH.register { entity, _ ->
             entity.eachTracker { tracker ->
+                tracker.forRemoval(true)
                 val animated = tracker.animate(
                     "death",
                     AnimationModifier.DEFAULT_WITH_PLAY_ONCE
@@ -196,8 +197,11 @@ object EntityManager : GlobalManager {
                     tracker.close()
                 }
 
-                if (animated) {
-                    tracker.forRemoval(true)
+                if (!animated) {
+                    // No death animation — schedule forced close after vanilla death sequence (20 ticks)
+                    tracker.sourceEntity().platform().taskLater(20) {
+                        if (!tracker.isClosed) tracker.close()
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- **EntityTracker**: `updateBaseEntity()`에서 `asyncTaskLater` → `taskLater(entity)`로 변경 — entity state 읽기를 owning region thread에서 실행
- **EntityBodyRotator**: `pitch()`, `bodyYaw()`, `headYaw()`, `yaw()`, `onWalk()` 직접 호출을 `throttleTickFloat`/`throttleTickBoolean`으로 래핑 — EXECUTOR 워커 스레드에서 NMS 핸들 직접 읽기 방지 (Folia 스레드 소유권 위반 해결)
- **EntityManager (Bukkit + Fabric)**: 사망 핸들러에서 `forRemoval(true)`를 항상 설정 — death 애니메이션 유무와 무관하게 트래커가 사망 상태로 표시됨
- **EntityTrackerRegistry#despawn()**: `forRemoval` 트래커를 스킵하지 않고 `close()` 호출 — 엔티티가 월드에서 제거될 때 확실히 정리

## Context

### 회전값 throttle (EntityBodyRotator)
`bodyRotation0()`, `stableBodyYaw()`, head/body supplier 람다에서 `entity.pitch()`, `entity.bodyYaw()` 등이 EXECUTOR 10ms tick에서 직접 호출됨. Folia에서는 이 값들이 Region Thread에서만 원자적으로 업데이트되므로, 다른 스레드에서 읽으면 stale read 또는 스레드 소유권 검증 실패 발생.

기존 `FunctionUtil.throttleTickFloat` 패턴(`AtomicLong.compareAndSet` + `volatile cache`)을 활용하여 50ms 간격 thread-safe 캐싱 적용. `EntityTracker`에서 `damageTick`, `walkSpeed` 등은 이미 이 패턴 사용 중이었으나 `EntityBodyRotator`는 미적용 상태였음.

### 사망 모델 잔류 (EntityManager + EntityTrackerRegistry)
death 애니메이션이 없는 몹 사망 시:
1. `animate("death")` → `false` 반환
2. 기존: `forRemoval(true)` 미호출 → 트래커 활성 상태 유지
3. `EntityRemoveFromWorldEvent` → `despawn()` → `forRemoval` 안 되어있으니 `despawn()` 호출 → `entity.dead()` 시점에 따라 `close()` 안 될 수 있음

수정 후:
1. `forRemoval(true)` 항상 설정
2. `despawn()`에서 `forRemoval` 트래커를 `close()` → `EntityRemoveFromWorldEvent` 시점에 확실히 정리

## Test plan
- [ ] Folia 서버에서 모델 적용 엔티티 이동/회전 싱크 확인
- [ ] 빠른 방향 전환 시 모델 회전 추종 확인
- [ ] 사망 애니메이션 없는 몹 사망 → 모델 사라지는지 확인
- [ ] 사망 애니메이션 있는 몹 사망 → 애니메이션 재생 후 모델 사라지는지 확인
- [ ] 청크 경계에서 몹 사망 → 모델 잔류 없는지 확인
- [ ] 서버 로그에 `Thread failed main thread check` 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)