### PR TITLE
feat: add head item to player animations

### DIFF
--- a/api/bukkit-api/src/main/java/kr/toxicity/model/api/bukkit/entity/BaseBukkitEntity.java
+++ b/api/bukkit-api/src/main/java/kr/toxicity/model/api/bukkit/entity/BaseBukkitEntity.java
@@ -79,6 +79,24 @@ public interface BaseBukkitEntity extends BaseEntity, PersistentDataHolder {
     }
 
     /**
+     * Returns the item in the entity's helmet slot.
+     *
+     * @return the helmet item
+     * @since 2.0.1
+     */
+    @Override
+    default @NotNull TransformedItemStack helmet() {
+        if (entity() instanceof LivingEntity livingEntity) {
+            var equipment = livingEntity.getEquipment();
+            if (equipment != null) {
+                var helmet = equipment.getHelmet();
+                if (helmet != null) return TransformedItemStack.of(BukkitAdapter.adapt(helmet));
+            }
+        }
+        return TransformedItemStack.empty();
+    }
+
+    /**
      * Retrieves the model data stored in the entity's persistent data container.
      *
      * @return the model data string, or null if not present

--- a/api/src/main/java/kr/toxicity/model/api/bone/BoneTags.java
+++ b/api/src/main/java/kr/toxicity/model/api/bone/BoneTags.java
@@ -73,6 +73,18 @@ public enum BoneTags implements BoneTag {
         BaseEntity::mainHand
     ), "pri", "ri"),
     /**
+     * Entity's helmet item
+     * <p>
+     * A built-in scale correction of {@code 0.5} is applied because
+     * {@link PlatformItemTransform#HEAD} renders items at 2× the scale
+     * relative to the animation bone coordinate system.
+     * </p>
+     */
+    HEAD_ITEM(BoneItemMapper.entity(
+        PlatformItemTransform.HEAD,
+        entity -> entity.helmet().withScale(0.5f)
+    ), "phi"),
+    /**
      * Player head
      */
     PLAYER_HEAD(PlayerLimb.HEAD.getItemMapper(), "ph"),

--- a/api/src/main/java/kr/toxicity/model/api/entity/BaseEntity.java
+++ b/api/src/main/java/kr/toxicity/model/api/entity/BaseEntity.java
@@ -177,6 +177,15 @@ public interface BaseEntity extends Identifiable {
     @NotNull TransformedItemStack offHand();
 
     /**
+     * Gets helmet item
+     * @return helmet
+     * @since 2.0.1
+     */
+    default @NotNull TransformedItemStack helmet() {
+        return TransformedItemStack.empty();
+    }
+
+    /**
      * Gets tracker registry of this adapter
      * @return optional tracker registry
      */

--- a/api/src/main/java/kr/toxicity/model/api/util/TransformedItemStack.java
+++ b/api/src/main/java/kr/toxicity/model/api/util/TransformedItemStack.java
@@ -70,6 +70,15 @@ public record TransformedItemStack(@NotNull Vector3f position, @NotNull Vector3f
     }
 
     /**
+     * Sets a uniform scale
+     * @param scale uniform scale factor
+     * @return new item with the given scale
+     */
+    public @NotNull TransformedItemStack withScale(float scale) {
+        return of(position, offset, new Vector3f(scale), itemStack);
+    }
+
+    /**
      * Modify item
      * @param mapper mapper
      * @return modified item

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/BaseFabricEntityImpl.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/BaseFabricEntityImpl.kt
@@ -16,6 +16,7 @@ import net.kyori.adventure.text.Component
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.effect.MobEffects
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.ai.attributes.Attributes
 import org.joml.Vector3f
@@ -123,6 +124,15 @@ class BaseFabricEntityImpl(private var entity: Entity) : BaseFabricEntity {
         val entity = entity
         return if (entity is LivingEntity) {
             TransformedItemStack.of(entity.offhandItem.wrap())
+        } else {
+            TransformedItemStack.empty()
+        }
+    }
+
+    override fun helmet(): TransformedItemStack {
+        val entity = entity
+        return if (entity is LivingEntity) {
+            TransformedItemStack.of(entity.getItemBySlot(EquipmentSlot.HEAD).wrap())
         } else {
             TransformedItemStack.empty()
         }


### PR DESCRIPTION
A start to sync head items (for bones prefixed with phi) for limb animations. The scaling however is still a bit off, but without it the item would be way too large.

Resolves #251 