### PR TITLE
Fix Blockbench 5 animation loading and display metadata

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     compileOnly(libs.bundles.minecraft)
+    testImplementation(libs.bundles.minecraft)
 }

--- a/api/src/main/java/kr/toxicity/model/api/bone/BoneItemMapper.java
+++ b/api/src/main/java/kr/toxicity/model/api/bone/BoneItemMapper.java
@@ -51,8 +51,6 @@ public interface BoneItemMapper extends BiFunction<BoneRenderContext, Transforme
     static @NotNull BoneItemMapper player(@NotNull PlatformItemTransform transform, @NotNull Function<PlatformPlayer, TransformedItemStack> mapper) {
         return new BoneItemMapper() {
 
-            private static final TransformedItemStack AIR = TransformedItemStack.empty();
-
             @NotNull
             @Override
             public PlatformItemTransform transform() {
@@ -63,7 +61,7 @@ public interface BoneItemMapper extends BiFunction<BoneRenderContext, Transforme
             public @NotNull TransformedItemStack apply(@NotNull BoneRenderContext context, @NotNull TransformedItemStack transformedItemStack) {
                 if (context.source() instanceof RenderSource.BasePlayer(PlatformPlayer player)) {
                     var get = mapper.apply(player);
-                    return get == null ? AIR : get;
+                    return get == null ? TransformedItemStack.empty() : get;
                 }
                 return transformedItemStack;
             }
@@ -79,8 +77,6 @@ public interface BoneItemMapper extends BiFunction<BoneRenderContext, Transforme
     static @NotNull BoneItemMapper entity(@NotNull PlatformItemTransform transform, @NotNull Function<BaseEntity, TransformedItemStack> mapper) {
         return new BoneItemMapper() {
 
-            private static final TransformedItemStack AIR = TransformedItemStack.empty();
-
             @NotNull
             @Override
             public PlatformItemTransform transform() {
@@ -91,7 +87,7 @@ public interface BoneItemMapper extends BiFunction<BoneRenderContext, Transforme
             public @NotNull TransformedItemStack apply(@NotNull BoneRenderContext context, @NotNull TransformedItemStack transformedItemStack) {
                 if (context.source() instanceof RenderSource.Entity entity) {
                     var get = mapper.apply(entity.entity());
-                    return get == null ? AIR : get;
+                    return get == null ? TransformedItemStack.empty() : get;
                 }
                 return transformedItemStack;
             }

--- a/api/src/main/java/kr/toxicity/model/api/data/blueprint/AnimationGenerator.java
+++ b/api/src/main/java/kr/toxicity/model/api/data/blueprint/AnimationGenerator.java
@@ -121,8 +121,9 @@ public final class AnimationGenerator {
                 time
             );
             for (float f = 1; f < length; f++) {
-                if (secondTime - addTime < time + MathUtil.FRAME_EPSILON) continue;
-                floats.add(firstTime + f * addTime);
+                var add = firstTime + f * addTime;
+                if (secondTime - add < time + MathUtil.FRAME_EPSILON) break;
+                floats.add(add);
             }
         }
     }
@@ -186,13 +187,13 @@ public final class AnimationGenerator {
         }
 
         private float tree(float first, float second, @NotNull Function<BlueprintAnimator.AnimatorData, List<VectorPoint>> mapper) {
-            var value = data != null ? mapper.apply(data) : Collections.<VectorPoint>emptyList();
-            return findTree(first, second, value).length();
+            return findTree(first, second, mapper).length();
         }
 
-        private @NotNull Vector3f findTree(float first, float second, @NotNull List<VectorPoint> target) {
-            var get = find(first, second, target);
-            return parent != null ? parent.findTree(first, second, target).add(get) : get;
+        private @NotNull Vector3f findTree(float first, float second, @NotNull Function<BlueprintAnimator.AnimatorData, List<VectorPoint>> mapper) {
+            var value = data != null ? mapper.apply(data) : Collections.<VectorPoint>emptyList();
+            var get = find(first, second, value);
+            return parent != null ? parent.findTree(first, second, mapper).add(get) : get;
         }
         private @NotNull Vector3f find(float first, float second, @NotNull List<VectorPoint> target) {
             return find(second, target).sub(find(first, target), new Vector3f());

--- a/api/src/test/kotlin/kr/toxicity/model/api/data/raw/Blockbench5CompatibilityTest.kt
+++ b/api/src/test/kotlin/kr/toxicity/model/api/data/raw/Blockbench5CompatibilityTest.kt
@@ -1,0 +1,270 @@
+/*
+ * This source file is part of BetterModel.
+ * Copyright (c) 2026 toxicity188
+ * Licensed under the MIT License.
+ * See LICENSE.md file for full license text.
+ */
+
+package kr.toxicity.model.api.data.raw
+
+import kr.toxicity.model.api.BetterModel
+import kr.toxicity.model.api.BetterModelConfig
+import kr.toxicity.model.api.BetterModelEvaluator
+import kr.toxicity.model.api.BetterModelPlatform
+import kr.toxicity.model.api.util.function.Float2FloatFunction
+import java.io.File
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTimedValue
+
+class Blockbench5CompatibilityTest {
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun loadsBlockbench5GroupedAnimation() {
+        registerTestPlatform()
+
+        val result = measureTimedValue {
+            val data = ModelData.GSON.fromJson(blockbench5Model, ModelData::class.java)
+            data.assertSupported()
+            data.loadBlueprint("blockbench5_grouped_animation", false)
+        }
+
+        assertTrue(result.duration < 2.seconds, "Blockbench 5 grouped animation loading should not run away.")
+        assertTrue(result.value.errors().isEmpty(), result.value.errors().joinToString("\n"))
+        assertEquals(1, result.value.blueprint().animations().size)
+        assertEquals(3, result.value.blueprint().animations().getValue("spin").animator().size)
+    }
+
+    private companion object {
+        private const val ROOT = "00000000-0000-0000-0000-000000000001"
+        private const val CHILD = "00000000-0000-0000-0000-000000000002"
+        private const val LEAF = "00000000-0000-0000-0000-000000000003"
+        private const val CUBE = "00000000-0000-0000-0000-000000000004"
+        private const val ANIMATION = "00000000-0000-0000-0000-000000000005"
+
+        private fun registerTestPlatform() {
+            runCatching { BetterModel.platform() }.onSuccess { return }
+
+            val config = Proxy.newProxyInstance(
+                BetterModelConfig::class.java.classLoader,
+                arrayOf(BetterModelConfig::class.java),
+            ) { _, method, _ ->
+                when (method.name) {
+                    "lerpFrameTime" -> 0
+                    else -> defaultReturn(method)
+                }
+            } as BetterModelConfig
+            val evaluator = BetterModelEvaluator { Float2FloatFunction.ZERO }
+            val platform = Proxy.newProxyInstance(
+                BetterModelPlatform::class.java.classLoader,
+                arrayOf(BetterModelPlatform::class.java),
+            ) { _, method, _ ->
+                when (method.name) {
+                    "config" -> config
+                    "evaluator" -> evaluator
+                    "dataFolder" -> File(".")
+                    else -> defaultReturn(method)
+                }
+            } as BetterModelPlatform
+
+            BetterModel.register(platform)
+        }
+
+        private fun defaultReturn(method: Method): Any? = when (val type = method.returnType) {
+            java.lang.Boolean.TYPE -> false
+            java.lang.Byte.TYPE -> 0.toByte()
+            java.lang.Short.TYPE -> 0.toShort()
+            java.lang.Integer.TYPE -> 0
+            java.lang.Long.TYPE -> 0L
+            java.lang.Float.TYPE -> 0F
+            java.lang.Double.TYPE -> 0.0
+            java.lang.Character.TYPE -> 0.toChar()
+            java.lang.Void.TYPE -> null
+            String::class.java -> ""
+            else -> if (type.isEnum) type.enumConstants.firstOrNull() else null
+        }
+
+        private val blockbench5Model = """
+            {
+              "meta": {
+                "format_version": "5.0",
+                "model_format": "free",
+                "box_uv": false
+              },
+              "name": "blockbench5_grouped_animation",
+              "resolution": {
+                "width": 16,
+                "height": 16
+              },
+              "textures": [],
+              "elements": [
+                {
+                  "name": "cube",
+                  "uuid": "$CUBE",
+                  "from": [0, 0, 0],
+                  "to": [1, 1, 1],
+                  "origin": [0, 0, 0],
+                  "faces": {},
+                  "type": "cube"
+                }
+              ],
+              "groups": [
+                {
+                  "name": "root",
+                  "uuid": "$ROOT",
+                  "origin": [0, 0, 0],
+                  "rotation": [0, 0, 0],
+                  "visibility": true
+                },
+                {
+                  "name": "child",
+                  "uuid": "$CHILD",
+                  "origin": [0, 0, 0],
+                  "rotation": [0, 0, 0],
+                  "visibility": true
+                },
+                {
+                  "name": "leaf",
+                  "uuid": "$LEAF",
+                  "origin": [0, 0, 0],
+                  "rotation": [0, 0, 0],
+                  "visibility": true
+                }
+              ],
+              "outliner": [
+                {
+                  "name": "root",
+                  "uuid": "$ROOT",
+                  "origin": [0, 0, 0],
+                  "children": [
+                    {
+                      "name": "child",
+                      "uuid": "$CHILD",
+                      "origin": [0, 0, 0],
+                      "children": [
+                        {
+                          "name": "leaf",
+                          "uuid": "$LEAF",
+                          "origin": [0, 0, 0],
+                          "children": [
+                            "$CUBE"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "animations": [
+                {
+                  "name": "spin",
+                  "loop": "once",
+                  "override": false,
+                  "uuid": "$ANIMATION",
+                  "length": 1,
+                  "animators": {
+                    "$ROOT": {
+                      "name": "root",
+                      "type": "bone",
+                      "rotation_global": false,
+                      "keyframes": [
+                        {
+                          "channel": "rotation",
+                          "time": 0,
+                          "interpolation": "linear",
+                          "data_points": [
+                            {
+                              "x": 0,
+                              "y": 0,
+                              "z": 0
+                            }
+                          ]
+                        },
+                        {
+                          "channel": "rotation",
+                          "time": 1,
+                          "interpolation": "linear",
+                          "data_points": [
+                            {
+                              "x": 720,
+                              "y": 0,
+                              "z": 0
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "$CHILD": {
+                      "name": "child",
+                      "type": "bone",
+                      "rotation_global": false,
+                      "keyframes": [
+                        {
+                          "channel": "rotation",
+                          "time": 0,
+                          "interpolation": "linear",
+                          "data_points": [
+                            {
+                              "x": 0,
+                              "y": 0,
+                              "z": 0
+                            }
+                          ]
+                        },
+                        {
+                          "channel": "rotation",
+                          "time": 1,
+                          "interpolation": "linear",
+                          "data_points": [
+                            {
+                              "x": 0,
+                              "y": 720,
+                              "z": 0
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "$LEAF": {
+                      "name": "leaf",
+                      "type": "bone",
+                      "rotation_global": false,
+                      "keyframes": [
+                        {
+                          "channel": "rotation",
+                          "time": 0,
+                          "interpolation": "linear",
+                          "data_points": [
+                            {
+                              "x": 0,
+                              "y": 0,
+                              "z": 0
+                            }
+                          ]
+                        },
+                        {
+                          "channel": "rotation",
+                          "time": 1,
+                          "interpolation": "linear",
+                          "data_points": [
+                            {
+                              "x": 0,
+                              "y": 0,
+                              "z": 720
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+}

--- a/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/EntityData.kt
+++ b/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/EntityData.kt
@@ -30,7 +30,19 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     it.toEntityDataAccessor()
 }
 
+internal fun Class<*>.accessor(name: String) = declaredFields.first { f ->
+    f.name == name
+}.toEntityDataAccessor()
+
 internal val DISPLAY_SET = Display::class.java.accessors()
+internal val DISPLAY_BILLBOARD = Display::class.java.accessor("DATA_BILLBOARD_RENDER_CONSTRAINTS_ID")
+internal val DISPLAY_BRIGHTNESS = Display::class.java.accessor("DATA_BRIGHTNESS_OVERRIDE_ID")
+internal val DISPLAY_VIEW_RANGE = Display::class.java.accessor("DATA_VIEW_RANGE_ID")
+internal val DISPLAY_SHADOW_RADIUS = Display::class.java.accessor("DATA_SHADOW_RADIUS_ID")
+internal val DISPLAY_SHADOW_STRENGTH = Display::class.java.accessor("DATA_SHADOW_STRENGTH_ID")
+internal val DISPLAY_WIDTH = Display::class.java.accessor("DATA_WIDTH_ID")
+internal val DISPLAY_HEIGHT = Display::class.java.accessor("DATA_HEIGHT_ID")
+internal val DISPLAY_GLOW_COLOR = Display::class.java.accessor("DATA_GLOW_COLOR_OVERRIDE_ID")
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
 internal val ITEM_DISPLAY_ID = ItemDisplay::class.java.accessors().map {
     it.id
@@ -40,21 +52,28 @@ internal val ITEM_ENTITY_DATA = buildList {
     add(SHARED_FLAG)
     addAll(ITEM_DISPLAY_ID)
     add(Display.DATA_POS_ROT_INTERPOLATION_DURATION_ID.id)
-    DISPLAY_SET.subList(7, DISPLAY_SET.size).mapTo(this) { it.id }
+    add(DISPLAY_BILLBOARD.id)
+    add(DISPLAY_BRIGHTNESS.id)
+    add(DISPLAY_VIEW_RANGE.id)
+    add(DISPLAY_SHADOW_RADIUS.id)
+    add(DISPLAY_SHADOW_STRENGTH.id)
+    add(DISPLAY_WIDTH.id)
+    add(DISPLAY_HEIGHT.id)
+    add(DISPLAY_GLOW_COLOR.id)
 }.toIntSet()
 
 @Suppress("UNCHECKED_CAST")
-private val DISPLAY_INTERPOLATION_DELAY = (DISPLAY_SET.first() as EntityDataAccessor<Int>).run {
+private val DISPLAY_INTERPOLATION_DELAY = (Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID") as EntityDataAccessor<Int>).run {
     SynchedEntityData.DataValue(id, serializer, 0)
 }
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_INTERPOLATION_DURATION = DISPLAY_SET[1] as EntityDataAccessor<Int>
+internal val DISPLAY_INTERPOLATION_DURATION = Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID") as EntityDataAccessor<Int>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_TRANSLATION = DISPLAY_SET[3] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_TRANSLATION = Display::class.java.accessor("DATA_TRANSLATION_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_SCALE = DISPLAY_SET[4] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_SCALE = Display::class.java.accessor("DATA_SCALE_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_ROTATION = DISPLAY_SET[5] as EntityDataAccessor<Quaternionf>
+internal val DISPLAY_ROTATION = Display::class.java.accessor("DATA_LEFT_ROTATION_ID") as EntityDataAccessor<Quaternionf>
 
 
 internal class TransformationData {
@@ -123,4 +142,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/EntityData.kt
+++ b/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/EntityData.kt
@@ -30,7 +30,19 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     it.toEntityDataAccessor()
 }
 
+internal fun Class<*>.accessor(name: String) = declaredFields.first { f ->
+    f.name == name
+}.toEntityDataAccessor()
+
 internal val DISPLAY_SET = Display::class.java.accessors()
+internal val DISPLAY_BILLBOARD = Display::class.java.accessor("DATA_BILLBOARD_RENDER_CONSTRAINTS_ID")
+internal val DISPLAY_BRIGHTNESS = Display::class.java.accessor("DATA_BRIGHTNESS_OVERRIDE_ID")
+internal val DISPLAY_VIEW_RANGE = Display::class.java.accessor("DATA_VIEW_RANGE_ID")
+internal val DISPLAY_SHADOW_RADIUS = Display::class.java.accessor("DATA_SHADOW_RADIUS_ID")
+internal val DISPLAY_SHADOW_STRENGTH = Display::class.java.accessor("DATA_SHADOW_STRENGTH_ID")
+internal val DISPLAY_WIDTH = Display::class.java.accessor("DATA_WIDTH_ID")
+internal val DISPLAY_HEIGHT = Display::class.java.accessor("DATA_HEIGHT_ID")
+internal val DISPLAY_GLOW_COLOR = Display::class.java.accessor("DATA_GLOW_COLOR_OVERRIDE_ID")
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
 internal val ITEM_DISPLAY_ID = ItemDisplay::class.java.accessors().map {
     it.id
@@ -40,21 +52,28 @@ internal val ITEM_ENTITY_DATA = buildList {
     add(SHARED_FLAG)
     addAll(ITEM_DISPLAY_ID)
     add(Display.DATA_POS_ROT_INTERPOLATION_DURATION_ID.id)
-    DISPLAY_SET.subList(7, DISPLAY_SET.size).mapTo(this) { it.id }
+    add(DISPLAY_BILLBOARD.id)
+    add(DISPLAY_BRIGHTNESS.id)
+    add(DISPLAY_VIEW_RANGE.id)
+    add(DISPLAY_SHADOW_RADIUS.id)
+    add(DISPLAY_SHADOW_STRENGTH.id)
+    add(DISPLAY_WIDTH.id)
+    add(DISPLAY_HEIGHT.id)
+    add(DISPLAY_GLOW_COLOR.id)
 }.toIntSet()
 
 @Suppress("UNCHECKED_CAST")
-private val DISPLAY_INTERPOLATION_DELAY = (DISPLAY_SET.first() as EntityDataAccessor<Int>).run {
+private val DISPLAY_INTERPOLATION_DELAY = (Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID") as EntityDataAccessor<Int>).run {
     SynchedEntityData.DataValue(id, serializer, 0)
 }
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_INTERPOLATION_DURATION = DISPLAY_SET[1] as EntityDataAccessor<Int>
+internal val DISPLAY_INTERPOLATION_DURATION = Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID") as EntityDataAccessor<Int>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_TRANSLATION = DISPLAY_SET[3] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_TRANSLATION = Display::class.java.accessor("DATA_TRANSLATION_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_SCALE = DISPLAY_SET[4] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_SCALE = Display::class.java.accessor("DATA_SCALE_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_ROTATION = DISPLAY_SET[5] as EntityDataAccessor<Quaternionf>
+internal val DISPLAY_ROTATION = Display::class.java.accessor("DATA_LEFT_ROTATION_ID") as EntityDataAccessor<Quaternionf>
 
 
 internal class TransformationData {
@@ -123,4 +142,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/EntityData.kt
+++ b/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/EntityData.kt
@@ -30,7 +30,19 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     it.toEntityDataAccessor()
 }
 
+internal fun Class<*>.accessor(name: String) = declaredFields.first { f ->
+    f.name == name
+}.toEntityDataAccessor()
+
 internal val DISPLAY_SET = Display::class.java.accessors()
+internal val DISPLAY_BILLBOARD = Display::class.java.accessor("DATA_BILLBOARD_RENDER_CONSTRAINTS_ID")
+internal val DISPLAY_BRIGHTNESS = Display::class.java.accessor("DATA_BRIGHTNESS_OVERRIDE_ID")
+internal val DISPLAY_VIEW_RANGE = Display::class.java.accessor("DATA_VIEW_RANGE_ID")
+internal val DISPLAY_SHADOW_RADIUS = Display::class.java.accessor("DATA_SHADOW_RADIUS_ID")
+internal val DISPLAY_SHADOW_STRENGTH = Display::class.java.accessor("DATA_SHADOW_STRENGTH_ID")
+internal val DISPLAY_WIDTH = Display::class.java.accessor("DATA_WIDTH_ID")
+internal val DISPLAY_HEIGHT = Display::class.java.accessor("DATA_HEIGHT_ID")
+internal val DISPLAY_GLOW_COLOR = Display::class.java.accessor("DATA_GLOW_COLOR_OVERRIDE_ID")
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
 internal val ITEM_DISPLAY_ID = ItemDisplay::class.java.accessors().map {
     it.id
@@ -40,21 +52,28 @@ internal val ITEM_ENTITY_DATA = buildList {
     add(SHARED_FLAG)
     addAll(ITEM_DISPLAY_ID)
     add(Display.DATA_POS_ROT_INTERPOLATION_DURATION_ID.id)
-    DISPLAY_SET.subList(7, DISPLAY_SET.size).mapTo(this) { it.id }
+    add(DISPLAY_BILLBOARD.id)
+    add(DISPLAY_BRIGHTNESS.id)
+    add(DISPLAY_VIEW_RANGE.id)
+    add(DISPLAY_SHADOW_RADIUS.id)
+    add(DISPLAY_SHADOW_STRENGTH.id)
+    add(DISPLAY_WIDTH.id)
+    add(DISPLAY_HEIGHT.id)
+    add(DISPLAY_GLOW_COLOR.id)
 }.toIntSet()
 
 @Suppress("UNCHECKED_CAST")
-private val DISPLAY_INTERPOLATION_DELAY = (DISPLAY_SET.first() as EntityDataAccessor<Int>).run {
+private val DISPLAY_INTERPOLATION_DELAY = (Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID") as EntityDataAccessor<Int>).run {
     SynchedEntityData.DataValue(id, serializer, 0)
 }
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_INTERPOLATION_DURATION = DISPLAY_SET[1] as EntityDataAccessor<Int>
+internal val DISPLAY_INTERPOLATION_DURATION = Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID") as EntityDataAccessor<Int>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_TRANSLATION = DISPLAY_SET[3] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_TRANSLATION = Display::class.java.accessor("DATA_TRANSLATION_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_SCALE = DISPLAY_SET[4] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_SCALE = Display::class.java.accessor("DATA_SCALE_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_ROTATION = DISPLAY_SET[5] as EntityDataAccessor<Quaternionf>
+internal val DISPLAY_ROTATION = Display::class.java.accessor("DATA_LEFT_ROTATION_ID") as EntityDataAccessor<Quaternionf>
 
 
 internal class TransformationData {
@@ -123,4 +142,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/EntityData.kt
+++ b/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/EntityData.kt
@@ -30,7 +30,19 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     it.toEntityDataAccessor()
 }
 
+internal fun Class<*>.accessor(name: String) = declaredFields.first { f ->
+    f.name == name
+}.toEntityDataAccessor()
+
 internal val DISPLAY_SET = Display::class.java.accessors()
+internal val DISPLAY_BILLBOARD = Display::class.java.accessor("DATA_BILLBOARD_RENDER_CONSTRAINTS_ID")
+internal val DISPLAY_BRIGHTNESS = Display::class.java.accessor("DATA_BRIGHTNESS_OVERRIDE_ID")
+internal val DISPLAY_VIEW_RANGE = Display::class.java.accessor("DATA_VIEW_RANGE_ID")
+internal val DISPLAY_SHADOW_RADIUS = Display::class.java.accessor("DATA_SHADOW_RADIUS_ID")
+internal val DISPLAY_SHADOW_STRENGTH = Display::class.java.accessor("DATA_SHADOW_STRENGTH_ID")
+internal val DISPLAY_WIDTH = Display::class.java.accessor("DATA_WIDTH_ID")
+internal val DISPLAY_HEIGHT = Display::class.java.accessor("DATA_HEIGHT_ID")
+internal val DISPLAY_GLOW_COLOR = Display::class.java.accessor("DATA_GLOW_COLOR_OVERRIDE_ID")
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
 internal val ITEM_DISPLAY_ID = ItemDisplay::class.java.accessors().map {
     it.id
@@ -40,21 +52,28 @@ internal val ITEM_ENTITY_DATA = buildList {
     add(SHARED_FLAG)
     addAll(ITEM_DISPLAY_ID)
     add(Display.DATA_POS_ROT_INTERPOLATION_DURATION_ID.id)
-    DISPLAY_SET.subList(7, DISPLAY_SET.size).mapTo(this) { it.id }
+    add(DISPLAY_BILLBOARD.id)
+    add(DISPLAY_BRIGHTNESS.id)
+    add(DISPLAY_VIEW_RANGE.id)
+    add(DISPLAY_SHADOW_RADIUS.id)
+    add(DISPLAY_SHADOW_STRENGTH.id)
+    add(DISPLAY_WIDTH.id)
+    add(DISPLAY_HEIGHT.id)
+    add(DISPLAY_GLOW_COLOR.id)
 }.toIntSet()
 
 @Suppress("UNCHECKED_CAST")
-private val DISPLAY_INTERPOLATION_DELAY = (DISPLAY_SET.first() as EntityDataAccessor<Int>).run {
+private val DISPLAY_INTERPOLATION_DELAY = (Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID") as EntityDataAccessor<Int>).run {
     SynchedEntityData.DataValue(id, serializer, 0)
 }
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_INTERPOLATION_DURATION = DISPLAY_SET[1] as EntityDataAccessor<Int>
+internal val DISPLAY_INTERPOLATION_DURATION = Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID") as EntityDataAccessor<Int>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_TRANSLATION = DISPLAY_SET[3] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_TRANSLATION = Display::class.java.accessor("DATA_TRANSLATION_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_SCALE = DISPLAY_SET[4] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_SCALE = Display::class.java.accessor("DATA_SCALE_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_ROTATION = DISPLAY_SET[5] as EntityDataAccessor<Quaternionf>
+internal val DISPLAY_ROTATION = Display::class.java.accessor("DATA_LEFT_ROTATION_ID") as EntityDataAccessor<Quaternionf>
 
 
 internal class TransformationData {
@@ -123,4 +142,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/EntityData.kt
+++ b/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/EntityData.kt
@@ -30,7 +30,19 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     it.toEntityDataAccessor()
 }
 
+internal fun Class<*>.accessor(name: String) = declaredFields.first { f ->
+    f.name == name
+}.toEntityDataAccessor()
+
 internal val DISPLAY_SET = Display::class.java.accessors()
+internal val DISPLAY_BILLBOARD = Display::class.java.accessor("DATA_BILLBOARD_RENDER_CONSTRAINTS_ID")
+internal val DISPLAY_BRIGHTNESS = Display::class.java.accessor("DATA_BRIGHTNESS_OVERRIDE_ID")
+internal val DISPLAY_VIEW_RANGE = Display::class.java.accessor("DATA_VIEW_RANGE_ID")
+internal val DISPLAY_SHADOW_RADIUS = Display::class.java.accessor("DATA_SHADOW_RADIUS_ID")
+internal val DISPLAY_SHADOW_STRENGTH = Display::class.java.accessor("DATA_SHADOW_STRENGTH_ID")
+internal val DISPLAY_WIDTH = Display::class.java.accessor("DATA_WIDTH_ID")
+internal val DISPLAY_HEIGHT = Display::class.java.accessor("DATA_HEIGHT_ID")
+internal val DISPLAY_GLOW_COLOR = Display::class.java.accessor("DATA_GLOW_COLOR_OVERRIDE_ID")
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
 internal val ITEM_DISPLAY_ID = ItemDisplay::class.java.accessors().map {
     it.id
@@ -40,21 +52,28 @@ internal val ITEM_ENTITY_DATA = buildList {
     add(SHARED_FLAG)
     addAll(ITEM_DISPLAY_ID)
     add(Display.DATA_POS_ROT_INTERPOLATION_DURATION_ID.id)
-    DISPLAY_SET.subList(7, DISPLAY_SET.size).mapTo(this) { it.id }
+    add(DISPLAY_BILLBOARD.id)
+    add(DISPLAY_BRIGHTNESS.id)
+    add(DISPLAY_VIEW_RANGE.id)
+    add(DISPLAY_SHADOW_RADIUS.id)
+    add(DISPLAY_SHADOW_STRENGTH.id)
+    add(DISPLAY_WIDTH.id)
+    add(DISPLAY_HEIGHT.id)
+    add(DISPLAY_GLOW_COLOR.id)
 }.toIntSet()
 
 @Suppress("UNCHECKED_CAST")
-private val DISPLAY_INTERPOLATION_DELAY = (DISPLAY_SET.first() as EntityDataAccessor<Int>).run {
+private val DISPLAY_INTERPOLATION_DELAY = (Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID") as EntityDataAccessor<Int>).run {
     SynchedEntityData.DataValue(id, serializer, 0)
 }
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_INTERPOLATION_DURATION = DISPLAY_SET[1] as EntityDataAccessor<Int>
+internal val DISPLAY_INTERPOLATION_DURATION = Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID") as EntityDataAccessor<Int>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_TRANSLATION = DISPLAY_SET[3] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_TRANSLATION = Display::class.java.accessor("DATA_TRANSLATION_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_SCALE = DISPLAY_SET[4] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_SCALE = Display::class.java.accessor("DATA_SCALE_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_ROTATION = DISPLAY_SET[5] as EntityDataAccessor<Quaternionf>
+internal val DISPLAY_ROTATION = Display::class.java.accessor("DATA_LEFT_ROTATION_ID") as EntityDataAccessor<Quaternionf>
 
 
 internal class TransformationData {
@@ -123,4 +142,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/EntityData.kt
+++ b/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/EntityData.kt
@@ -30,7 +30,19 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     it.toEntityDataAccessor()
 }
 
+internal fun Class<*>.accessor(name: String) = declaredFields.first { f ->
+    f.name == name
+}.toEntityDataAccessor()
+
 internal val DISPLAY_SET = Display::class.java.accessors()
+internal val DISPLAY_BILLBOARD = Display::class.java.accessor("DATA_BILLBOARD_RENDER_CONSTRAINTS_ID")
+internal val DISPLAY_BRIGHTNESS = Display::class.java.accessor("DATA_BRIGHTNESS_OVERRIDE_ID")
+internal val DISPLAY_VIEW_RANGE = Display::class.java.accessor("DATA_VIEW_RANGE_ID")
+internal val DISPLAY_SHADOW_RADIUS = Display::class.java.accessor("DATA_SHADOW_RADIUS_ID")
+internal val DISPLAY_SHADOW_STRENGTH = Display::class.java.accessor("DATA_SHADOW_STRENGTH_ID")
+internal val DISPLAY_WIDTH = Display::class.java.accessor("DATA_WIDTH_ID")
+internal val DISPLAY_HEIGHT = Display::class.java.accessor("DATA_HEIGHT_ID")
+internal val DISPLAY_GLOW_COLOR = Display::class.java.accessor("DATA_GLOW_COLOR_OVERRIDE_ID")
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
 internal val ITEM_DISPLAY_ID = ItemDisplay::class.java.accessors().map {
     it.id
@@ -40,21 +52,28 @@ internal val ITEM_ENTITY_DATA = buildList {
     add(SHARED_FLAG)
     addAll(ITEM_DISPLAY_ID)
     add(Display.DATA_POS_ROT_INTERPOLATION_DURATION_ID.id)
-    DISPLAY_SET.subList(7, DISPLAY_SET.size).mapTo(this) { it.id }
+    add(DISPLAY_BILLBOARD.id)
+    add(DISPLAY_BRIGHTNESS.id)
+    add(DISPLAY_VIEW_RANGE.id)
+    add(DISPLAY_SHADOW_RADIUS.id)
+    add(DISPLAY_SHADOW_STRENGTH.id)
+    add(DISPLAY_WIDTH.id)
+    add(DISPLAY_HEIGHT.id)
+    add(DISPLAY_GLOW_COLOR.id)
 }.toIntSet()
 
 @Suppress("UNCHECKED_CAST")
-private val DISPLAY_INTERPOLATION_DELAY = (DISPLAY_SET.first() as EntityDataAccessor<Int>).run {
+private val DISPLAY_INTERPOLATION_DELAY = (Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID") as EntityDataAccessor<Int>).run {
     SynchedEntityData.DataValue(id, serializer, 0)
 }
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_INTERPOLATION_DURATION = DISPLAY_SET[1] as EntityDataAccessor<Int>
+internal val DISPLAY_INTERPOLATION_DURATION = Display::class.java.accessor("DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID") as EntityDataAccessor<Int>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_TRANSLATION = DISPLAY_SET[3] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_TRANSLATION = Display::class.java.accessor("DATA_TRANSLATION_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_SCALE = DISPLAY_SET[4] as EntityDataAccessor<Vector3f>
+internal val DISPLAY_SCALE = Display::class.java.accessor("DATA_SCALE_ID") as EntityDataAccessor<Vector3f>
 @Suppress("UNCHECKED_CAST")
-internal val DISPLAY_ROTATION = DISPLAY_SET[5] as EntityDataAccessor<Quaternionf>
+internal val DISPLAY_ROTATION = Display::class.java.accessor("DATA_LEFT_ROTATION_ID") as EntityDataAccessor<Quaternionf>
 
 
 internal class TransformationData {
@@ -123,4 +142,3 @@ internal class TransformationData {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

  This PR fixes two compatibility issues found while testing BetterModel v3 with newer Blockbench 5 models and Minecraft 1.21 display entity metadata.

  ## Changes

  - Fix Blockbench 5 grouped animation loading by using each parent bone’s own animation data during recursive rotation accumulation.
  - Fix animation interpolation frame insertion so generated intermediate frames stay inside the active keyframe segment.
  - Avoid early BetterModel platform initialization from `BoneItemMapper` by lazily creating empty transformed item stacks.
  - Replace reflection-order-based Display metadata indexing with explicit named `EntityDataAccessor` lookups across NMS modules.
  - Add a regression test that loads a minimal Blockbench 5 grouped animation model.

  ## Why

  Blockbench 5 models with nested `groups` could load incorrectly or hang because parent rotation deltas were calculated using the child bone’s keyframes. Separately, Display entity metadata was relying on reflected field order, which can map the wrong value type to a client metadata index and cause client protocol crashes such as `Invalid entity data item type`.

  ## Validation

  - `bash ./gradlew :bettermodel-api:test`
  - `bash ./gradlew build`