### PR TITLE
fix crash on folia

### DIFF
--- a/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/HitBoxImpl.kt
+++ b/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/HitBoxImpl.kt
@@ -11,6 +11,7 @@ import io.papermc.paper.event.entity.EntityKnockbackEvent
 import kr.toxicity.model.api.BetterModel
 import kr.toxicity.model.api.bone.BoneMovement
 import kr.toxicity.model.api.bone.RenderedBone
+import kr.toxicity.model.api.bukkit.BetterModelBukkit
 import kr.toxicity.model.api.config.DebugConfig
 import kr.toxicity.model.api.data.blueprint.ModelBoundingBox
 import kr.toxicity.model.api.event.hitbox.*
@@ -89,12 +90,23 @@ internal class HitBoxImpl(
         persist = false
         isSilent = true
         initialized = true
-        level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        level().addFreshEntity(interaction.apply {
-            moveTo(delegate.position())
-        }, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        interaction.startRiding(this)
-        listener.handle(HitBoxCreateEvent(this))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                level().addFreshEntity(this@HitBoxImpl, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                level().addFreshEntity(interaction.apply {
+                    moveTo(delegate.position())
+                }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                interaction.startRiding(this@HitBoxImpl)
+                listener.handle(HitBoxCreateEvent(this@HitBoxImpl))
+            }
+        } else {
+            level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            level().addFreshEntity(interaction.apply {
+                moveTo(delegate.position())
+            }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            interaction.startRiding(this)
+            listener.handle(HitBoxCreateEvent(this))
+        }
     }
 
     private fun initialSetup() {
@@ -130,32 +142,68 @@ internal class HitBoxImpl(
 
     override fun mount(entity: PlatformEntity) {
         if (controllingPassenger != null) return
-        if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
-            if (mountController.canControl()) {
-                mounted = true
-                noGravity = delegate.isNoGravity
-                ifLivingEntity {
-                    collision = collides
-                    collides = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                if (controllingPassenger != null) return@task
+                if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                    if (mountController.canControl()) {
+                        mounted = true
+                        noGravity = delegate.isNoGravity
+                        ifLivingEntity {
+                            collision = collides
+                            collides = false
+                        }
+                    }
+                    listener.handle(HitBoxMountEvent(this, entity))
                 }
             }
-            listener.handle(HitBoxMountEvent(this, entity))
+        } else {
+            if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                if (mountController.canControl()) {
+                    mounted = true
+                    noGravity = delegate.isNoGravity
+                    ifLivingEntity {
+                        collision = collides
+                        collides = false
+                    }
+                }
+                listener.handle(HitBoxMountEvent(this, entity))
+            }
         }
     }
 
     override fun dismount(entity: PlatformEntity) {
-        forceDismount = true
-        if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
-        forceDismount = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+            forceDismount = false
+        }
     }
 
     override fun dismountAll() {
-        forceDismount = true
-        interaction.passengers.forEach {
-            it.stopRiding(true)
-            listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                interaction.passengers.forEach {
+                    it.stopRiding(true)
+                    listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+                }
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            interaction.passengers.forEach {
+                it.stopRiding(true)
+                listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+            }
+            forceDismount = false
         }
-        forceDismount = false
     }
 
     override fun setRemainingFireTicks(remainingFireTicks: Int) {

--- a/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/HitBoxImpl.kt
+++ b/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/HitBoxImpl.kt
@@ -91,12 +91,23 @@ internal class HitBoxImpl(
         persist = false
         isSilent = true
         initialized = true
-        level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        level().addFreshEntity(interaction.apply {
-            moveTo(delegate.position())
-        }, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        interaction.startRiding(this)
-        listener.handle(HitBoxCreateEvent(this))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                level().addFreshEntity(this@HitBoxImpl, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                level().addFreshEntity(interaction.apply {
+                    moveTo(delegate.position())
+                }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                interaction.startRiding(this@HitBoxImpl)
+                listener.handle(HitBoxCreateEvent(this@HitBoxImpl))
+            }
+        } else {
+            level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            level().addFreshEntity(interaction.apply {
+                moveTo(delegate.position())
+            }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            interaction.startRiding(this)
+            listener.handle(HitBoxCreateEvent(this))
+        }
     }
 
     private fun initialSetup() {
@@ -132,32 +143,68 @@ internal class HitBoxImpl(
 
     override fun mount(entity: PlatformEntity) {
         if (controllingPassenger != null) return
-        if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
-            if (mountController.canControl()) {
-                mounted = true
-                noGravity = delegate.isNoGravity
-                ifLivingEntity {
-                    collision = collides
-                    collides = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                if (controllingPassenger != null) return@task
+                if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                    if (mountController.canControl()) {
+                        mounted = true
+                        noGravity = delegate.isNoGravity
+                        ifLivingEntity {
+                            collision = collides
+                            collides = false
+                        }
+                    }
+                    listener.handle(HitBoxMountEvent(this, entity))
                 }
             }
-            listener.handle(HitBoxMountEvent(this, entity))
+        } else {
+            if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                if (mountController.canControl()) {
+                    mounted = true
+                    noGravity = delegate.isNoGravity
+                    ifLivingEntity {
+                        collision = collides
+                        collides = false
+                    }
+                }
+                listener.handle(HitBoxMountEvent(this, entity))
+            }
         }
     }
 
     override fun dismount(entity: PlatformEntity) {
-        forceDismount = true
-        if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
-        forceDismount = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+            forceDismount = false
+        }
     }
 
     override fun dismountAll() {
-        forceDismount = true
-        interaction.passengers.forEach {
-            it.stopRiding(true)
-            listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                interaction.passengers.forEach {
+                    it.stopRiding(true)
+                    listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+                }
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            interaction.passengers.forEach {
+                it.stopRiding(true)
+                listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+            }
+            forceDismount = false
         }
-        forceDismount = false
     }
 
     override fun setRemainingFireTicks(remainingFireTicks: Int) {

--- a/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/HitBoxImpl.kt
+++ b/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/HitBoxImpl.kt
@@ -91,12 +91,23 @@ internal class HitBoxImpl(
         persist = false
         isSilent = true
         initialized = true
-        level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        level().addFreshEntity(interaction.apply {
-            moveTo(delegate.position())
-        }, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        interaction.startRiding(this)
-        listener.handle(HitBoxCreateEvent(this))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                level().addFreshEntity(this@HitBoxImpl, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                level().addFreshEntity(interaction.apply {
+                    moveTo(delegate.position())
+                }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                interaction.startRiding(this@HitBoxImpl)
+                listener.handle(HitBoxCreateEvent(this@HitBoxImpl))
+            }
+        } else {
+            level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            level().addFreshEntity(interaction.apply {
+                moveTo(delegate.position())
+            }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            interaction.startRiding(this)
+            listener.handle(HitBoxCreateEvent(this))
+        }
     }
 
     private fun initialSetup() {
@@ -132,32 +143,68 @@ internal class HitBoxImpl(
 
     override fun mount(entity: PlatformEntity) {
         if (controllingPassenger != null) return
-        if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
-            if (mountController.canControl()) {
-                mounted = true
-                noGravity = delegate.isNoGravity
-                ifLivingEntity {
-                    collision = collides
-                    collides = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                if (controllingPassenger != null) return@task
+                if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                    if (mountController.canControl()) {
+                        mounted = true
+                        noGravity = delegate.isNoGravity
+                        ifLivingEntity {
+                            collision = collides
+                            collides = false
+                        }
+                    }
+                    listener.handle(HitBoxMountEvent(this, entity))
                 }
             }
-            listener.handle(HitBoxMountEvent(this, entity))
+        } else {
+            if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                if (mountController.canControl()) {
+                    mounted = true
+                    noGravity = delegate.isNoGravity
+                    ifLivingEntity {
+                        collision = collides
+                        collides = false
+                    }
+                }
+                listener.handle(HitBoxMountEvent(this, entity))
+            }
         }
     }
 
     override fun dismount(entity: PlatformEntity) {
-        forceDismount = true
-        if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
-        forceDismount = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+            forceDismount = false
+        }
     }
 
     override fun dismountAll() {
-        forceDismount = true
-        interaction.passengers.forEach {
-            it.stopRiding(true)
-            listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                interaction.passengers.forEach {
+                    it.stopRiding(true)
+                    listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+                }
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            interaction.passengers.forEach {
+                it.stopRiding(true)
+                listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+            }
+            forceDismount = false
         }
-        forceDismount = false
     }
 
     override fun setRemainingFireTicks(remainingFireTicks: Int) {

--- a/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/HitBoxImpl.kt
+++ b/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/HitBoxImpl.kt
@@ -91,12 +91,23 @@ internal class HitBoxImpl(
         persist = false
         isSilent = true
         initialized = true
-        level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        level().addFreshEntity(interaction.apply {
-            moveTo(delegate.position())
-        }, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        interaction.startRiding(this)
-        listener.handle(HitBoxCreateEvent(this))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                level().addFreshEntity(this@HitBoxImpl, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                level().addFreshEntity(interaction.apply {
+                    moveTo(delegate.position())
+                }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                interaction.startRiding(this@HitBoxImpl)
+                listener.handle(HitBoxCreateEvent(this@HitBoxImpl))
+            }
+        } else {
+            level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            level().addFreshEntity(interaction.apply {
+                moveTo(delegate.position())
+            }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            interaction.startRiding(this)
+            listener.handle(HitBoxCreateEvent(this))
+        }
     }
 
     private fun initialSetup() {
@@ -132,32 +143,68 @@ internal class HitBoxImpl(
 
     override fun mount(entity: PlatformEntity) {
         if (controllingPassenger != null) return
-        if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
-            if (mountController.canControl()) {
-                mounted = true
-                noGravity = delegate.isNoGravity
-                ifLivingEntity {
-                    collision = collides
-                    collides = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                if (controllingPassenger != null) return@task
+                if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                    if (mountController.canControl()) {
+                        mounted = true
+                        noGravity = delegate.isNoGravity
+                        ifLivingEntity {
+                            collision = collides
+                            collides = false
+                        }
+                    }
+                    listener.handle(HitBoxMountEvent(this, entity))
                 }
             }
-            listener.handle(HitBoxMountEvent(this, entity))
+        } else {
+            if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                if (mountController.canControl()) {
+                    mounted = true
+                    noGravity = delegate.isNoGravity
+                    ifLivingEntity {
+                        collision = collides
+                        collides = false
+                    }
+                }
+                listener.handle(HitBoxMountEvent(this, entity))
+            }
         }
     }
 
     override fun dismount(entity: PlatformEntity) {
-        forceDismount = true
-        if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
-        forceDismount = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+            forceDismount = false
+        }
     }
 
     override fun dismountAll() {
-        forceDismount = true
-        interaction.passengers.forEach {
-            it.stopRiding(true)
-            listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                interaction.passengers.forEach {
+                    it.stopRiding(true)
+                    listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+                }
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            interaction.passengers.forEach {
+                it.stopRiding(true)
+                listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+            }
+            forceDismount = false
         }
-        forceDismount = false
     }
 
     override fun setRemainingFireTicks(remainingFireTicks: Int) {

--- a/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/HitBoxImpl.kt
+++ b/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/HitBoxImpl.kt
@@ -91,12 +91,23 @@ internal class HitBoxImpl(
         persist = false
         isSilent = true
         initialized = true
-        level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        level().addFreshEntity(interaction.apply {
-            moveTo(delegate.position())
-        }, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        interaction.startRiding(this)
-        listener.handle(HitBoxCreateEvent(this))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                level().addFreshEntity(this@HitBoxImpl, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                level().addFreshEntity(interaction.apply {
+                    moveTo(delegate.position())
+                }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                interaction.startRiding(this@HitBoxImpl)
+                listener.handle(HitBoxCreateEvent(this@HitBoxImpl))
+            }
+        } else {
+            level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            level().addFreshEntity(interaction.apply {
+                moveTo(delegate.position())
+            }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            interaction.startRiding(this)
+            listener.handle(HitBoxCreateEvent(this))
+        }
     }
 
     private fun initialSetup() {
@@ -132,32 +143,68 @@ internal class HitBoxImpl(
 
     override fun mount(entity: PlatformEntity) {
         if (controllingPassenger != null) return
-        if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
-            if (mountController.canControl()) {
-                mounted = true
-                noGravity = delegate.isNoGravity
-                ifLivingEntity {
-                    collision = collides
-                    collides = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                if (controllingPassenger != null) return@task
+                if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                    if (mountController.canControl()) {
+                        mounted = true
+                        noGravity = delegate.isNoGravity
+                        ifLivingEntity {
+                            collision = collides
+                            collides = false
+                        }
+                    }
+                    listener.handle(HitBoxMountEvent(this, entity))
                 }
             }
-            listener.handle(HitBoxMountEvent(this, entity))
+        } else {
+            if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                if (mountController.canControl()) {
+                    mounted = true
+                    noGravity = delegate.isNoGravity
+                    ifLivingEntity {
+                        collision = collides
+                        collides = false
+                    }
+                }
+                listener.handle(HitBoxMountEvent(this, entity))
+            }
         }
     }
 
     override fun dismount(entity: PlatformEntity) {
-        forceDismount = true
-        if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
-        forceDismount = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+            forceDismount = false
+        }
     }
 
     override fun dismountAll() {
-        forceDismount = true
-        interaction.passengers.forEach {
-            it.stopRiding(true)
-            listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                interaction.passengers.forEach {
+                    it.stopRiding(true)
+                    listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+                }
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            interaction.passengers.forEach {
+                it.stopRiding(true)
+                listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+            }
+            forceDismount = false
         }
-        forceDismount = false
     }
 
     override fun setRemainingFireTicks(remainingFireTicks: Int) {

--- a/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/HitBoxImpl.kt
+++ b/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/HitBoxImpl.kt
@@ -91,12 +91,23 @@ internal class HitBoxImpl(
         persist = false
         isSilent = true
         initialized = true
-        level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        level().addFreshEntity(interaction.apply {
-            moveTo(delegate.position())
-        }, CreatureSpawnEvent.SpawnReason.CUSTOM)
-        interaction.startRiding(this)
-        listener.handle(HitBoxCreateEvent(this))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                level().addFreshEntity(this@HitBoxImpl, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                level().addFreshEntity(interaction.apply {
+                    moveTo(delegate.position())
+                }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+                interaction.startRiding(this@HitBoxImpl)
+                listener.handle(HitBoxCreateEvent(this@HitBoxImpl))
+            }
+        } else {
+            level().addFreshEntity(this, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            level().addFreshEntity(interaction.apply {
+                moveTo(delegate.position())
+            }, CreatureSpawnEvent.SpawnReason.CUSTOM)
+            interaction.startRiding(this)
+            listener.handle(HitBoxCreateEvent(this))
+        }
     }
 
     private fun initialSetup() {
@@ -132,32 +143,68 @@ internal class HitBoxImpl(
 
     override fun mount(entity: PlatformEntity) {
         if (controllingPassenger != null) return
-        if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
-            if (mountController.canControl()) {
-                mounted = true
-                noGravity = delegate.isNoGravity
-                ifLivingEntity {
-                    collision = collides
-                    collides = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                if (controllingPassenger != null) return@task
+                if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                    if (mountController.canControl()) {
+                        mounted = true
+                        noGravity = delegate.isNoGravity
+                        ifLivingEntity {
+                            collision = collides
+                            collides = false
+                        }
+                    }
+                    listener.handle(HitBoxMountEvent(this, entity))
                 }
             }
-            listener.handle(HitBoxMountEvent(this, entity))
+        } else {
+            if (interaction.bukkitEntity.addPassenger(entity.unwarp())) {
+                if (mountController.canControl()) {
+                    mounted = true
+                    noGravity = delegate.isNoGravity
+                    ifLivingEntity {
+                        collision = collides
+                        collides = false
+                    }
+                }
+                listener.handle(HitBoxMountEvent(this, entity))
+            }
         }
     }
 
     override fun dismount(entity: PlatformEntity) {
-        forceDismount = true
-        if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
-        forceDismount = false
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            if (interaction.bukkitEntity.removePassenger(entity.unwarp())) listener.handle(HitBoxDismountEvent(this, entity))
+            forceDismount = false
+        }
     }
 
     override fun dismountAll() {
-        forceDismount = true
-        interaction.passengers.forEach {
-            it.stopRiding(true)
-            listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+        if (BetterModelBukkit.IS_FOLIA) {
+            source().task {
+                forceDismount = true
+                interaction.passengers.forEach {
+                    it.stopRiding(true)
+                    listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+                }
+                forceDismount = false
+            }
+        } else {
+            forceDismount = true
+            interaction.passengers.forEach {
+                it.stopRiding(true)
+                listener.handle(HitBoxDismountEvent(this, it.bukkitEntity.wrap()))
+            }
+            forceDismount = false
         }
-        forceDismount = false
     }
 
     override fun setRemainingFireTicks(remainingFireTicks: Int) {


### PR DESCRIPTION

[11:52:20] [Folia Region Scheduler Thread #48/ERROR]: [ca.spottedleaf.moonrise.common.util.TickThread] Thread failed main thread check: Entity status change must only happen on the main thread, context=[thread=Folia Region Scheduler Thread #48,class=io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner,region={center=[-364, 100],world=world}], entity={root=[{type=CollisionInteraction,id=644833,uuid=6130aa57-afec-4c4e-9272-79b44eddc117,pos=(-5,951.500,96.000,1,863.500),mot=(0.000,0.000,0.000),aabb=AABB[-5951.800000011921, 96.0, 1863.199999988079] -> [-5951.199999988079, 96.60014743805517, 1863.800000011921],removed=null,has_vehicle=false,passenger_count=0], vehicle=[{null}], passengers=[]
java.lang.Throwable
	at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:97) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup.checkThread(ServerEntityLookup.java:58) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup.entityStatusChange(EntityLookup.java:236) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices.updateStatus(ChunkEntitySlices.java:255) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup.chunkStatusChange(EntityLookup.java:334) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.NewChunkHolder.changeEntityChunkStatus(NewChunkHolder.java:1188) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.NewChunkHolder.handleFullStatusChange(NewChunkHolder.java:1260) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.processPendingFullUpdate(ChunkHolderManager.java:1633) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.lambda$addChangedStatuses$8(ChunkHolderManager.java:1281) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedTaskQueue$PrioritisedQueue$ChunkBasedPriorityTask.executeInternal(RegionizedTaskQueue.java:529) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedTaskQueue$PrioritisedQueue.executeTask(RegionizedTaskQueue.java:456) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedTaskQueue$RegionTaskQueueData.executeChunkTask(RegionizedTaskQueue.java:253) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerChunkCache$MainThreadExecutor.pollTask(ServerChunkCache.java:923) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerChunkCache.pollTask(ServerChunkCache.java:435) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.tickMidTickTasks(MinecraftServer.java:459) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.moonrise$executeMidTickTasks(MinecraftServer.java:473) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerLevel.moonrise$midTickTasks(ServerLevel.java:347) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.world.level.Level.guardEntityTick(Level.java:1510) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerLevel.lambda$tick$4(ServerLevel.java:895) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedWorldData.forEachTickingEntity(RegionizedWorldData.java:723) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:869) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1967) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1765) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:430) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:487) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:500) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool$TickThreadRunner.run(EDFSchedulerThreadPool.java:526) ~[concurrentutil-0.0.8.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
[11:52:20] [Folia Region Scheduler Thread #48/ERROR]: [io.papermc.paper.threadedregions.TickRegionScheduler] Region #22504 centered at chunk [-364, 100] in world 'world' failed to tick:
net.minecraft.ReportedException: Exception ticking world
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1972) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1765) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:430) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:487) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:500) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool$TickThreadRunner.run(EDFSchedulerThreadPool.java:526) ~[concurrentutil-0.0.8.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: java.lang.IllegalStateException: Thread failed main thread check: Entity status change must only happen on the main thread, context=[thread=Folia Region Scheduler Thread #48,class=io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner,region={center=[-364, 100],world=world}], entity={root=[{type=CollisionInteraction,id=644833,uuid=6130aa57-afec-4c4e-9272-79b44eddc117,pos=(-5,951.500,96.000,1,863.500),mot=(0.000,0.000,0.000),aabb=AABB[-5951.800000011921, 96.0, 1863.199999988079] -> [-5951.199999988079, 96.60014743805517, 1863.800000011921],removed=null,has_vehicle=false,passenger_count=0], vehicle=[{null}], passengers=[]
	at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:98) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup.checkThread(ServerEntityLookup.java:58) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup.entityStatusChange(EntityLookup.java:236) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices.updateStatus(ChunkEntitySlices.java:255) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup.chunkStatusChange(EntityLookup.java:334) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.NewChunkHolder.changeEntityChunkStatus(NewChunkHolder.java:1188) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.NewChunkHolder.handleFullStatusChange(NewChunkHolder.java:1260) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.processPendingFullUpdate(ChunkHolderManager.java:1633) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.lambda$addChangedStatuses$8(ChunkHolderManager.java:1281) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedTaskQueue$PrioritisedQueue$ChunkBasedPriorityTask.executeInternal(RegionizedTaskQueue.java:529) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedTaskQueue$PrioritisedQueue.executeTask(RegionizedTaskQueue.java:456) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedTaskQueue$RegionTaskQueueData.executeChunkTask(RegionizedTaskQueue.java:253) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerChunkCache$MainThreadExecutor.pollTask(ServerChunkCache.java:923) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerChunkCache.pollTask(ServerChunkCache.java:435) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.tickMidTickTasks(MinecraftServer.java:459) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.moonrise$executeMidTickTasks(MinecraftServer.java:473) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerLevel.moonrise$midTickTasks(ServerLevel.java:347) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.world.level.Level.guardEntityTick(Level.java:1510) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerLevel.lambda$tick$4(ServerLevel.java:895) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at io.papermc.paper.threadedregions.RegionizedWorldData.forEachTickingEntity(RegionizedWorldData.java:723) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:869) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1967) ~[luminol-1.21.11.jar:1.21.11-DEV-8b41a91]
	... 6 more