### PR TITLE
fix: hitbox position not updating outside simulation distance

### DIFF
--- a/api/src/main/java/kr/toxicity/model/api/nms/HitBox.java
+++ b/api/src/main/java/kr/toxicity/model/api/nms/HitBox.java
@@ -196,6 +196,19 @@ public interface HitBox extends Identifiable {
     @NotNull RenderedBone positionSource();
 
     /**
+     * Synchronizes the position of this hitbox with its source entity.
+     * <p>
+     * This method ensures that the hitbox position follows its model even when
+     * it is outside the server's simulation distance. It should be called
+     * periodically from the entity tracker's tick system.
+     * </p>
+     *
+     * @since 3.3.2
+     */
+    @ApiStatus.Internal
+    void syncPosition();
+
+    /**
      * Returns the entity tracker registry for this hitbox's source entity.
      *
      * @return an optional containing the registry, or empty if not found

--- a/api/src/main/java/kr/toxicity/model/api/tracker/EntityTracker.java
+++ b/api/src/main/java/kr/toxicity/model/api/tracker/EntityTracker.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -149,6 +150,16 @@ public class EntityTracker extends Tracker {
         tick((_, _) -> updateLocation());
         tick((_, _) -> {
             if (damageTint.getAndDecrement() == 0) update(TrackerUpdateAction.previousTint());
+        });
+        tick((_, _) -> {
+            var hbs = new ArrayList<>(registry.hitBoxCache.values());
+            if (!hbs.isEmpty()) {
+                registry.entity().platform().task(() -> {
+                    for (var hb : hbs) {
+                        hb.syncPosition();
+                    }
+                });
+            }
         });
         rotation(bodyRotator::bodyRotation);
         preUpdateConsumer.accept(this);

--- a/api/src/main/java/kr/toxicity/model/api/tracker/EntityTrackerRegistry.java
+++ b/api/src/main/java/kr/toxicity/model/api/tracker/EntityTrackerRegistry.java
@@ -309,6 +309,7 @@ public final class EntityTrackerRegistry {
     }
 
     private void refreshPlayer() {
+        if (entity.dead()) return;
         entity.trackedBy()
             .map(p -> BetterModel.player(p.uuid()).orElse(null))
             .filter(Objects::nonNull)

--- a/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/HitBoxImpl.kt
+++ b/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/HitBoxImpl.kt
@@ -119,6 +119,18 @@ internal class HitBoxImpl(
     override fun relativePosition(): Vector3f = delegate.position().run {
         bone.hitBoxPosition(posCache).add(x.toFloat(), y.toFloat(), z.toFloat())
     }
+    override fun syncPosition() {
+        yRot = bone.rotation().y
+        yHeadRot = yRot
+        yBodyRot = yRot
+        val pos = relativePosition()
+        val minusHeight = source.minY * bone.hitBoxScale()
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
+    }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {
         this.listener = listener
@@ -287,11 +299,11 @@ internal class HitBoxImpl(
         yBodyRot = yRot
         val pos = relativePosition()
         val minusHeight = source.minY * bone.hitBoxScale()
-        setPos(
-            pos.x.toDouble(),
-            pos.y.toDouble() + minusHeight,
-            pos.z.toDouble()
-        )
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
         BlockPos.betweenClosedStream(boundingBox).forEach {
             level().getBlockState(it).entityInside(level(), it, delegate)
         }

--- a/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/HitBoxImpl.kt
+++ b/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/HitBoxImpl.kt
@@ -130,6 +130,13 @@ internal class HitBoxImpl(
         val targetZ = pos.z.toDouble()
         level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
         setPos(targetX, targetY, targetZ)
+        val dimension = dimensions
+        interaction.width = dimension.width
+        interaction.height = dimension.height
+        interaction.yRot = yRot
+        interaction.xRot = xRot
+        interaction.setSharedFlagOnFire(remainingFireTicks > 0)
+        interaction.isInvisible = delegate.isInvisible
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {

--- a/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/HitBoxImpl.kt
+++ b/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/HitBoxImpl.kt
@@ -133,6 +133,13 @@ internal class HitBoxImpl(
         val targetZ = pos.z.toDouble()
         level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
         setPos(targetX, targetY, targetZ)
+        val dimension = dimensions
+        interaction.width = dimension.width
+        interaction.height = dimension.height
+        interaction.yRot = yRot
+        interaction.xRot = xRot
+        interaction.setSharedFlagOnFire(remainingFireTicks > 0)
+        interaction.isInvisible = delegate.isInvisible
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {

--- a/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/HitBoxImpl.kt
+++ b/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/HitBoxImpl.kt
@@ -37,6 +37,7 @@ import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileDeflection
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.BlockGetter
+import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Bukkit
@@ -120,6 +121,18 @@ internal class HitBoxImpl(
     }
     override fun relativePosition(): Vector3f = delegate.position().run {
         bone.hitBoxPosition(posCache).add(x.toFloat(), y.toFloat(), z.toFloat())
+    }
+    override fun syncPosition() {
+        yRot = bone.rotation().y
+        yHeadRot = yRot
+        yBodyRot = yRot
+        val pos = relativePosition()
+        val minusHeight = source.minY * bone.hitBoxScale()
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {
@@ -273,11 +286,11 @@ internal class HitBoxImpl(
         yBodyRot = yRot
         val pos = relativePosition()
         val minusHeight = source.minY * bone.hitBoxScale()
-        setPos(
-            pos.x.toDouble(),
-            pos.y.toDouble() + minusHeight,
-            pos.z.toDouble()
-        )
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
         BlockGetter.forEachBlockIntersectedBetween(
             oldPosition(),
             position(),

--- a/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/HitBoxImpl.kt
+++ b/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/HitBoxImpl.kt
@@ -37,6 +37,7 @@ import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileDeflection
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.BlockGetter
+import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Bukkit
@@ -120,6 +121,18 @@ internal class HitBoxImpl(
     }
     override fun relativePosition(): Vector3f = delegate.position().run {
         bone.hitBoxPosition(posCache).add(x.toFloat(), y.toFloat(), z.toFloat())
+    }
+    override fun syncPosition() {
+        yRot = bone.rotation().y
+        yHeadRot = yRot
+        yBodyRot = yRot
+        val pos = relativePosition()
+        val minusHeight = source.minY * bone.hitBoxScale()
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {
@@ -289,11 +302,11 @@ internal class HitBoxImpl(
         yBodyRot = yRot
         val pos = relativePosition()
         val minusHeight = source.minY * bone.hitBoxScale()
-        setPos(
-            pos.x.toDouble(),
-            pos.y.toDouble() + minusHeight,
-            pos.z.toDouble()
-        )
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
         BlockGetter.forEachBlockIntersectedBetween(
             oldPosition(),
             position(),

--- a/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/HitBoxImpl.kt
+++ b/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/HitBoxImpl.kt
@@ -133,6 +133,13 @@ internal class HitBoxImpl(
         val targetZ = pos.z.toDouble()
         level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
         setPos(targetX, targetY, targetZ)
+        val dimension = dimensions
+        interaction.width = dimension.width
+        interaction.height = dimension.height
+        interaction.yRot = yRot
+        interaction.xRot = xRot
+        interaction.setSharedFlagOnFire(remainingFireTicks > 0)
+        interaction.isInvisible = delegate.isInvisible
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {

--- a/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/HitBoxImpl.kt
+++ b/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/HitBoxImpl.kt
@@ -37,6 +37,7 @@ import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileDeflection
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.BlockGetter
+import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Bukkit
@@ -120,6 +121,18 @@ internal class HitBoxImpl(
     }
     override fun relativePosition(): Vector3f = delegate.position().run {
         bone.hitBoxPosition(posCache).add(x.toFloat(), y.toFloat(), z.toFloat())
+    }
+    override fun syncPosition() {
+        yRot = bone.rotation().y
+        yHeadRot = yRot
+        yBodyRot = yRot
+        val pos = relativePosition()
+        val minusHeight = source.minY * bone.hitBoxScale()
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {
@@ -289,11 +302,11 @@ internal class HitBoxImpl(
         yBodyRot = yRot
         val pos = relativePosition()
         val minusHeight = source.minY * bone.hitBoxScale()
-        setPos(
-            pos.x.toDouble(),
-            pos.y.toDouble() + minusHeight,
-            pos.z.toDouble()
-        )
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
         BlockGetter.forEachBlockIntersectedBetween(
             oldPosition(),
             position(),

--- a/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/HitBoxImpl.kt
+++ b/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/HitBoxImpl.kt
@@ -133,6 +133,13 @@ internal class HitBoxImpl(
         val targetZ = pos.z.toDouble()
         level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
         setPos(targetX, targetY, targetZ)
+        val dimension = dimensions
+        interaction.width = dimension.width
+        interaction.height = dimension.height
+        interaction.yRot = yRot
+        interaction.xRot = xRot
+        interaction.setSharedFlagOnFire(remainingFireTicks > 0)
+        interaction.isInvisible = delegate.isInvisible
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {

--- a/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/HitBoxImpl.kt
+++ b/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/HitBoxImpl.kt
@@ -37,6 +37,7 @@ import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileDeflection
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.BlockGetter
+import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Bukkit
@@ -120,6 +121,18 @@ internal class HitBoxImpl(
     }
     override fun relativePosition(): Vector3f = delegate.position().run {
         bone.hitBoxPosition(posCache).add(x.toFloat(), y.toFloat(), z.toFloat())
+    }
+    override fun syncPosition() {
+        yRot = bone.rotation().y
+        yHeadRot = yRot
+        yBodyRot = yRot
+        val pos = relativePosition()
+        val minusHeight = source.minY * bone.hitBoxScale()
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {
@@ -289,11 +302,11 @@ internal class HitBoxImpl(
         yBodyRot = yRot
         val pos = relativePosition()
         val minusHeight = source.minY * bone.hitBoxScale()
-        setPos(
-            pos.x.toDouble(),
-            pos.y.toDouble() + minusHeight,
-            pos.z.toDouble()
-        )
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
         BlockGetter.forEachBlockIntersectedBetween(
             oldPosition(),
             position(),

--- a/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/HitBoxImpl.kt
+++ b/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/HitBoxImpl.kt
@@ -133,6 +133,13 @@ internal class HitBoxImpl(
         val targetZ = pos.z.toDouble()
         level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
         setPos(targetX, targetY, targetZ)
+        val dimension = dimensions
+        interaction.width = dimension.width
+        interaction.height = dimension.height
+        interaction.yRot = yRot
+        interaction.xRot = xRot
+        interaction.setSharedFlagOnFire(remainingFireTicks > 0)
+        interaction.isInvisible = delegate.isInvisible
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {

--- a/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/HitBoxImpl.kt
+++ b/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/HitBoxImpl.kt
@@ -37,6 +37,7 @@ import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileDeflection
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.BlockGetter
+import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Bukkit
@@ -120,6 +121,18 @@ internal class HitBoxImpl(
     }
     override fun relativePosition(): Vector3f = delegate.position().run {
         bone.hitBoxPosition(posCache).add(x.toFloat(), y.toFloat(), z.toFloat())
+    }
+    override fun syncPosition() {
+        yRot = bone.rotation().y
+        yHeadRot = yRot
+        yBodyRot = yRot
+        val pos = relativePosition()
+        val minusHeight = source.minY * bone.hitBoxScale()
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {
@@ -289,11 +302,11 @@ internal class HitBoxImpl(
         yBodyRot = yRot
         val pos = relativePosition()
         val minusHeight = source.minY * bone.hitBoxScale()
-        setPos(
-            pos.x.toDouble(),
-            pos.y.toDouble() + minusHeight,
-            pos.z.toDouble()
-        )
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
         BlockGetter.forEachBlockIntersectedBetween(
             oldPosition(),
             position(),

--- a/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/HitBoxImpl.kt
+++ b/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/HitBoxImpl.kt
@@ -133,6 +133,13 @@ internal class HitBoxImpl(
         val targetZ = pos.z.toDouble()
         level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
         setPos(targetX, targetY, targetZ)
+        val dimension = dimensions
+        interaction.width = dimension.width
+        interaction.height = dimension.height
+        interaction.yRot = yRot
+        interaction.xRot = xRot
+        interaction.setSharedFlagOnFire(remainingFireTicks > 0)
+        interaction.isInvisible = delegate.isInvisible
     }
     override fun listener(): HitBoxListener = listener
     override fun listener(listener: HitBoxListener) {

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/HitBoxEntityImpl.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/HitBoxEntityImpl.kt
@@ -140,6 +140,14 @@ class HitBoxEntityImpl(
         val targetZ = pos.z.toDouble()
         level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
         setPos(targetX, targetY, targetZ)
+        calculateDimensions().let { dimensions ->
+            interaction.width = dimensions.width
+            interaction.height = dimensions.height
+        }
+        interaction.yRot = yRot
+        interaction.xRot = xRot
+        interaction.setSharedFlagOnFire(remainingFireTicks > 0)
+        interaction.isInvisible = delegate.isInvisible
     }
 
     override fun listener(): HitBoxListener = listener

--- a/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/HitBoxEntityImpl.kt
+++ b/platform/fabric/src/main/kotlin/kr/toxicity/model/impl/fabric/entity/HitBoxEntityImpl.kt
@@ -36,6 +36,7 @@ import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileDeflection
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.BlockGetter
+import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
 import org.joml.Vector3f
@@ -126,6 +127,19 @@ class HitBoxEntityImpl(
             delegate.y.toFloat(),
             delegate.z.toFloat()
         )
+    }
+
+    override fun syncPosition() {
+        yRot = bone.rotation().y
+        yHeadRot = yRot
+        yBodyRot = yRot
+        val pos = relativePosition()
+        val minusHeight = source.minY * bone.hitBoxScale()
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
     }
 
     override fun listener(): HitBoxListener = listener
@@ -346,11 +360,11 @@ class HitBoxEntityImpl(
 
         val pos = relativePosition()
         val minusHeight = source.minY * bone.hitBoxScale()
-        setPos(
-            pos.x.toDouble(),
-            pos.y.toDouble() + minusHeight,
-            pos.z.toDouble()
-        )
+        val targetX = pos.x.toDouble()
+        val targetY = pos.y.toDouble() + minusHeight
+        val targetZ = pos.z.toDouble()
+        level().getChunkAt(BlockPos.containing(targetX, targetY, targetZ))
+        setPos(targetX, targetY, targetZ)
 
         BlockGetter.forEachBlockIntersectedBetween(
             oldPosition(),


### PR DESCRIPTION
## 🐛 Bug Fix

When the server simulation distance is too small, hitbox entities located outside 
the entity-ticking chunk range stop receiving `tick()` calls, causing them to freeze 
at their creation point and not follow the model.
