### PR TITLE
feat: allocator for a model part's custom_model_data

### DIFF
--- a/api/src/main/java/kr/toxicity/model/api/data/blueprint/BlueprintElement.java
+++ b/api/src/main/java/kr/toxicity/model/api/data/blueprint/BlueprintElement.java
@@ -130,7 +130,14 @@ public sealed interface BlueprintElement {
             return origin.invertXZ();
         }
 
-        private @NotNull String jsonName(@NotNull BlueprintLoadContext context) {
+        /**
+         * Returns the pack name of this group, which the generated JSON is named after.
+         *
+         * @param context the load context
+         * @return the pack name
+         * @since 3.4.0
+         */
+        public @NotNull String jsonName(@NotNull BlueprintLoadContext context) {
             return PackUtil.toPackName(context.name() + "_" + name.rawName());
         }
 

--- a/api/src/main/java/kr/toxicity/model/api/pack/PackModelDataAllocator.java
+++ b/api/src/main/java/kr/toxicity/model/api/pack/PackModelDataAllocator.java
@@ -1,0 +1,63 @@
+/*
+ * This source file is part of BetterModel.
+ * Copyright (c) 2026 toxicity188
+ * Licensed under the MIT License.
+ * See LICENSE.md file for full license text.
+ */
+
+package kr.toxicity.model.api.pack;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Defines a strategy for numbering the model parts of the pack.
+ * <p>
+ * The number becomes the item model's threshold and the item's custom_model_data.
+ * </p>
+ *
+ * @since 3.4.0
+ */
+@FunctionalInterface
+public interface PackModelDataAllocator {
+
+    /**
+     * Allocates the custom_model_data of the given model part.
+     *
+     * @param modelPart the pack name of the model part
+     * @return the custom_model_data
+     * @since 3.4.0
+     */
+    int allocate(@NotNull String modelPart);
+
+    /**
+     * Creates an order-based allocator.
+     *
+     * @return the allocator
+     * @since 3.4.0
+     */
+    static @NotNull PackModelDataAllocator order() {
+        return new Order();
+    }
+
+    /**
+     * An allocator that numbers model parts from one based on the order of appearance.
+     *
+     * @since 3.4.0
+     */
+    final class Order implements PackModelDataAllocator {
+
+        private final AtomicInteger indexer = new AtomicInteger(1);
+
+        /**
+         * Private initializer
+         */
+        private Order() {
+        }
+
+        public int allocate(@NotNull String modelPart) {
+            return indexer.getAndIncrement();
+        }
+    }
+}

--- a/api/src/main/java/kr/toxicity/model/api/pack/PackZipper.java
+++ b/api/src/main/java/kr/toxicity/model/api/pack/PackZipper.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -49,6 +50,7 @@ public final class PackZipper {
     private final PackObfuscator obfuscator = PackObfuscator.order();
     private final PackMeta.Builder metaBuilder = PackMeta.builder();
     private final Map<PackOverlay, PackAssets> overlayMap = new ConcurrentHashMap<>();
+    private volatile PackModelDataAllocator modelDataAllocator = PackModelDataAllocator.order();
 
     /**
      * Retrieves the default assets collection.
@@ -79,6 +81,26 @@ public final class PackZipper {
      */
     public @NotNull PackMeta.Builder metaBuilder() {
         return metaBuilder;
+    }
+
+    /**
+     * Returns the model data allocator.
+     *
+     * @return the allocator
+     * @since 3.4.0
+     */
+    public @NotNull PackModelDataAllocator modelDataAllocator() {
+        return modelDataAllocator;
+    }
+
+    /**
+     * Sets the model data allocator, which has to be done before the models are loaded.
+     *
+     * @param modelDataAllocator the allocator
+     * @since 3.4.0
+     */
+    public void modelDataAllocator(@NotNull PackModelDataAllocator modelDataAllocator) {
+        this.modelDataAllocator = Objects.requireNonNull(modelDataAllocator);
     }
 
     /**

--- a/core/src/main/kotlin/kr/toxicity/model/manager/ModelManagerImpl.kt
+++ b/core/src/main/kotlin/kr/toxicity/model/manager/ModelManagerImpl.kt
@@ -125,7 +125,7 @@ object ModelManagerImpl : ModelManager, GlobalManager {
         zipper: PackZipper
     ) : AutoCloseable {
 
-        private var indexer = 1
+        private val modelDataAllocator = zipper.modelDataAllocator()
         private var estimatedSize = 0L
         private val textures = zipper.assets().bettermodel().textures()
 
@@ -133,9 +133,9 @@ object ModelManagerImpl : ModelManager, GlobalManager {
             namespace = zipper.assets().obfuscate("modern_item"),
             builder = { zipper.assets().bettermodel().models().resolve(namespace) },
             available = true,
-            onBuild = { blueprints, json, size ->
+            onBuild = { blueprints, json, size, modelData ->
                 entries += jsonObjectOf(
-                    "threshold" to indexer,
+                    "threshold" to modelData,
                     "model" to blueprints.toModernJson(namespace, json)
                 )
                 blueprints.forEach { json ->
@@ -181,8 +181,9 @@ object ModelManagerImpl : ModelManager, GlobalManager {
                     val json = group.buildModernJson(obfuscator, context)
                     val itemModel = group.buildMeshItemModel(context)
                     if (json != null || itemModel != null) {
-                        build(json ?: emptyList(), itemModel, if (json != null) size / json.size else 0)
-                        indexer++
+                        modelDataAllocator.allocate(group.jsonName(context)).also { modelData ->
+                            build(json ?: emptyList(), itemModel, if (json != null) size / json.size else 0, modelData)
+                        }
                     } else null
                 }
             }.apply {
@@ -211,7 +212,7 @@ object ModelManagerImpl : ModelManager, GlobalManager {
             val namespace: String,
             val builder: ModelBuilder.() -> PackBuilder,
             private val available: Boolean,
-            private val onBuild: ModelBuilder.(List<BlueprintJson>, JsonObject?, Long) -> Unit,
+            private val onBuild: ModelBuilder.(List<BlueprintJson>, JsonObject?, Long, Int) -> Unit,
             private val onClose: ModelBuilder.() -> Unit
         ) : AutoCloseable {
             val entries = jsonArrayOf()
@@ -222,8 +223,8 @@ object ModelManagerImpl : ModelManager, GlobalManager {
                 return if (available) block() else null
             }
 
-            fun build(list: List<BlueprintJson>, json: JsonObject?, size: Long) {
-                onBuild(list, json, size)
+            fun build(list: List<BlueprintJson>, json: JsonObject?, size: Long, modelData: Int) {
+                onBuild(list, json, size, modelData)
             }
 
             override fun close() {


### PR DESCRIPTION
A generated pack only works on the server that generated it. I hit this trying to put one pack in front of a network.

`indexer` in `ModelPipeline` numbers each model part by where it sits in the loaded set. Add or remove one model and everything after it shifts. Two servers with different model folders end up numbering the same part differently.

That number isn't only in the pack, it's also what the server writes on the item in `PlatformItemStack#modelData`, so there's no fixing it downstream. Rewriting the pack doesn't help when the number comes off the server.

### What I measured

3.3.0, two Paper 1.21.11 servers, BetterModel the only plugin, `use-obfuscation: false`, `pack-type: folder`. `mmm_shared_wizard` and `nnn_shared_knight` are the same files on both servers, copies of the shipped `blue_wizard.bbmodel` and `demon_knight.bbmodel`.

```
A: aaa_lobby_only, mmm_shared_wizard, nnn_shared_knight
B: mmm_shared_wizard, nnn_shared_knight, zzz_pvp_only
```

The packs share 6032 paths and 6031 of them are byte identical. The odd one out is `assets/bettermodel/items/bm_models.json`. 56 model parts exist on both servers and not one gets the same threshold:

```
mmm_shared_wizard  first threshold   A=33   B=1
nnn_shared_knight  first threshold   A=65   B=33
```

32 apart, which is exactly how many thresholds A's extra model eats first. Take A's pack to B and every shared model points at the wrong thing.

### The change

New `PackModelDataAllocator`. One method, takes the pack name of a model part, returns its custom_model_data. `PackZipper` holds one and you swap it from `PluginStartReloadEvent`, which runs before any model is read.

`ModelManagerImpl` calls it once per part and uses that value both for the item model threshold and for the custom_model_data on the item, so the two can't get out of sync.

`BlueprintElement.Group#jsonName` goes from private to public. That's the key the allocator sees. I didn't invent an id for this, it's already the name the group's json gets (`bettermodel:modern_item/mmm_shared_wizard_body_1`), which is why it's the same on both servers.

I left the default dumb on purpose. Picking a real numbering means picking what happens on a collision and which ranges stay reserved, and that's the network owner's problem rather than the plugin's.

### Default output is untouched

`order()` counts from 1 in load order, same as `indexer` did. Same models, one pack off `v3`, one off this branch:

```
diff -r before/ after/     (no output)
```

6067 files, sha1'd one by one, all match.

### With an allocator supplied

Same two servers plus a throwaway plugin doing:

```java
event.zipper().modelDataAllocator(part -> (part.hashCode() & 0x7FFFFFFF) % 1000000 + 1);
```

56 shared parts. Without it, 0 matched. With it, all 56.

```
mmm_shared_wizard  first threshold   A=10436   B=10436
nnn_shared_knight  first threshold   A=7137    B=7137
```

`bm_models.json` still isn't identical between the two, since each server only lists the models it has. But the numbers they both use now mean the same thing, which is the part that matters.

---

BetterHud does the same thing in `ShaderManagerImpl#compileShader`, where a shader id is `index + 1` over the loaded set.
