### PR TITLE
fix: stabilize item display metadata packing

### DIFF
--- a/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/EntityData.kt
+++ b/nms/v1_21_R3/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R3/EntityData.kt
@@ -28,7 +28,7 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     EntityDataAccessor::class.java.isAssignableFrom(f.type)
 }.map {
     it.toEntityDataAccessor()
-}
+}.sortedBy { it.id }
 
 internal val DISPLAY_SET = Display::class.java.accessors()
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
@@ -123,4 +123,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/EntityData.kt
+++ b/nms/v1_21_R4/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R4/EntityData.kt
@@ -28,7 +28,7 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     EntityDataAccessor::class.java.isAssignableFrom(f.type)
 }.map {
     it.toEntityDataAccessor()
-}
+}.sortedBy { it.id }
 
 internal val DISPLAY_SET = Display::class.java.accessors()
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
@@ -123,4 +123,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/EntityData.kt
+++ b/nms/v1_21_R5/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R5/EntityData.kt
@@ -28,7 +28,7 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     EntityDataAccessor::class.java.isAssignableFrom(f.type)
 }.map {
     it.toEntityDataAccessor()
-}
+}.sortedBy { it.id }
 
 internal val DISPLAY_SET = Display::class.java.accessors()
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
@@ -123,4 +123,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/EntityData.kt
+++ b/nms/v1_21_R6/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R6/EntityData.kt
@@ -28,7 +28,7 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     EntityDataAccessor::class.java.isAssignableFrom(f.type)
 }.map {
     it.toEntityDataAccessor()
-}
+}.sortedBy { it.id }
 
 internal val DISPLAY_SET = Display::class.java.accessors()
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
@@ -123,4 +123,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/EntityData.kt
+++ b/nms/v1_21_R7/src/main/kotlin/kr/toxicity/model/bukkit/nms/v1_21_R7/EntityData.kt
@@ -28,7 +28,7 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     EntityDataAccessor::class.java.isAssignableFrom(f.type)
 }.map {
     it.toEntityDataAccessor()
-}
+}.sortedBy { it.id }
 
 internal val DISPLAY_SET = Display::class.java.accessors()
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
@@ -123,4 +123,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/EntityData.kt
+++ b/nms/v26_R1/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R1/EntityData.kt
@@ -28,7 +28,7 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     EntityDataAccessor::class.java.isAssignableFrom(f.type)
 }.map {
     it.toEntityDataAccessor()
-}
+}.sortedBy { it.id }
 
 internal val DISPLAY_SET = Display::class.java.accessors()
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
@@ -123,4 +123,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v26_R2/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R2/EntityData.kt
+++ b/nms/v26_R2/src/main/kotlin/kr/toxicity/model/bukkit/nms/v26_R2/EntityData.kt
@@ -28,7 +28,7 @@ internal fun Class<*>.accessors() = declaredFields.filter { f ->
     EntityDataAccessor::class.java.isAssignableFrom(f.type)
 }.map {
     it.toEntityDataAccessor()
-}
+}.sortedBy { it.id }
 
 internal val DISPLAY_SET = Display::class.java.accessors()
 internal val SHARED_FLAG = Entity::class.java.accessors().first().id
@@ -123,4 +123,3 @@ internal class TransformationData {
         }
     }
 }
-

--- a/nms/v26_R2/src/test/kotlin/kr/toxicity/model/bukkit/nms/v26_R2/EntityDataTest.kt
+++ b/nms/v26_R2/src/test/kotlin/kr/toxicity/model/bukkit/nms/v26_R2/EntityDataTest.kt
@@ -1,0 +1,61 @@
+/*
+ * This source file is part of BetterModel.
+ * Copyright (c) 2026 toxicity188
+ * Licensed under the MIT License.
+ * See LICENSE.md file for full license text.
+ */
+
+package kr.toxicity.model.bukkit.nms.v26_R2
+
+import net.minecraft.network.syncher.EntityDataSerializers
+import net.minecraft.world.entity.Display
+import org.joml.Quaternionf
+import org.joml.Vector3f
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class EntityDataTest {
+
+    @Test
+    fun `display accessors are ordered by metadata id`() {
+        val ids = Display::class.java.accessors().map { it.id }
+
+        assertTrue(ids.zipWithNext().all { (first, second) -> first < second })
+    }
+
+    @Test
+    fun `transformation data uses the expected metadata types`() {
+        val translation = Vector3f(1F, 2F, 3F)
+        val scale = Vector3f(4F, 5F, 6F)
+        val rotation = Quaternionf().rotationXYZ(0.1F, 0.2F, 0.3F)
+        val packed = TransformationData().apply {
+            transform(20, translation, scale, rotation)
+        }.pack()
+
+        assertEquals(listOf(8, 9, 11, 12, 13), packed.map { it.id })
+        assertEquals(packed.size, packed.map { it.id }.distinct().size)
+
+        assertSame(EntityDataSerializers.INT, packed[0].serializer)
+        assertIs<Int>(packed[0].value)
+        assertEquals(0, packed[0].value)
+
+        assertSame(EntityDataSerializers.INT, packed[1].serializer)
+        assertIs<Int>(packed[1].value)
+        assertEquals(20, packed[1].value)
+
+        assertSame(EntityDataSerializers.VECTOR3, packed[2].serializer)
+        assertIs<Vector3f>(packed[2].value)
+        assertEquals(translation, packed[2].value)
+
+        assertSame(EntityDataSerializers.VECTOR3, packed[3].serializer)
+        assertIs<Vector3f>(packed[3].value)
+        assertEquals(scale, packed[3].value)
+
+        assertSame(EntityDataSerializers.QUATERNION, packed[4].serializer)
+        assertIs<Quaternionf>(packed[4].value)
+        assertEquals(rotation, packed[4].value)
+    }
+}


### PR DESCRIPTION
Order each Bukkit NMS adapter's reflected `EntityDataAccessor` collection by accessor id before any existing positional selection, keeping the current field mapping and packet-building behavior otherwise unchanged. Apply the same minimal change across all maintained Bukkit NMS versions because these duplicated adapters are required to remain behaviorally equivalent; the Fabric implementation already uses named mixin accessors and is out of scope. Add a focused `v26_R2` regression test that checks accessor ordering and the complete `TransformationData.pack()` output, including unique expected ids and the correct serializer/value category for interpolation delay, integer duration, translation, scale, and rotation. BetterModel 3.3.0 can send an ItemDisplay metadata entry whose field id is the integer interpolation-duration field while its serializer and payload are for a float, causing vanilla 26.2 clients to disconnect with a network protocol error. The reported failure is intermittent under rapid model spawn/despawn load, but the field/type pair and the `v26_R2` transformation packing path are concrete. Bukkit NMS adapters currently collect `EntityDataAccessor` fields in raw `Class.getDeclaredFields()` order and then use positional indexes to select duration, translation, scale, and rotation accessors. That JVM field order is not a supported contract, while the accessors' numeric metadata ids provide the stable ordering the packet format requires.

Testing: With reflected `Display` accessors returned from `accessors()`, assert their ids are strictly ordered so positional selection cannot bind a later float accessor to the interpolation-duration slot; Pack a transformation with duration `20` and non-default translation, scale, and rotation; assert the duration entry uses the interpolation-duration id and integer serializer/value rather than a float serializer/value.

Fixes #405
