### PR TITLE
feat(api): add non-blocking Tracker close-and-drain completion receipt

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -4,4 +4,8 @@ plugins {
 
 dependencies {
     compileOnly(libs.bundles.minecraft)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.bundles.library)
+    testImplementation(libs.bundles.minecraft)
 }

--- a/api/src/main/java/kr/toxicity/model/api/tracker/Tracker.java
+++ b/api/src/main/java/kr/toxicity/model/api/tracker/Tracker.java
@@ -28,6 +28,7 @@ import kr.toxicity.model.api.script.TimeScript;
 import kr.toxicity.model.api.util.*;
 import kr.toxicity.model.api.util.function.BonePredicate;
 import kr.toxicity.model.api.util.function.FloatSupplier;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.ApiStatus;
@@ -83,6 +84,10 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
     private final Queue<Runnable> queuedTask = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean tickPause = new AtomicBoolean();
     private final AtomicBoolean isClosed = new AtomicBoolean();
+    private final AtomicBoolean quiesce = new AtomicBoolean();
+    private final CompletableFuture<Void> drainFuture = new CompletableFuture<>();
+    private volatile boolean ticking;
+    private boolean drainingTasks;
     private final AtomicBoolean readyForForceUpdate = new AtomicBoolean();
     private final AtomicBoolean forRemoval = new AtomicBoolean();
     private final AtomicBoolean firstStart = new AtomicBoolean();
@@ -153,6 +158,9 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
         });
         LogUtil.debug(DebugConfig.DebugOption.TRACKER, () -> getClass().getSimpleName() + " tracker created: " + name());
         pipeline.getSource().completeContext().thenAccept(context -> {
+            // The skin context can resolve long after construction; once the tracker is closed or
+            // draining, the source may already be gone, so this callback is invalidated.
+            if (isClosed() || quiesce.get()) return;
             if (pipeline.matchTree(bone -> bone.updateItem(context))) forceUpdate(true);
         });
     }
@@ -169,9 +177,9 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
     }
 
     private void start() {
-        if (isScheduled()) return;
+        if (isClosed() || isScheduled()) return;
         synchronized (this) {
-            if (isScheduled()) return;
+            if (isClosed() || isScheduled()) return;
             if (firstStart.compareAndSet(false, true)) {
                 TrackerBuiltInAnimation.play(this);
             }
@@ -189,10 +197,14 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
     }
 
     private void shutdown() {
+        shutdown(true);
+    }
+
+    private void shutdown(boolean interrupt) {
         if (!isScheduled()) return;
         synchronized (this) {
             if (!isScheduled()) return;
-            task.cancel(true);
+            task.cancel(interrupt);
             task = null;
             frame = 0;
             LogUtil.debug(DebugConfig.DebugOption.TRACKER, () -> getClass().getSimpleName() + " scheduler shutdown: " + name());
@@ -201,14 +213,58 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
 
     private void tick() {
         try {
-            if (frame % MINECRAFT_TICK_MULTIPLIER == 0) {
-                Runnable task;
-                while ((task = queuedTask.poll()) != null) task.run();
+            ticking = true;
+            try {
+                if (quiesce.get()) return;
+                if (frame % MINECRAFT_TICK_MULTIPLIER == 0) {
+                    Runnable task;
+                    while ((task = queuedTask.poll()) != null) task.run();
+                }
+                handler.handle(this, bundlerSet);
+                bundlerSet.send();
+            } finally {
+                ticking = false;
+                if (quiesce.get()) quiesceAndComplete();
             }
-            handler.handle(this, bundlerSet);
-            bundlerSet.send();
         } catch (Throwable throwable) {
             LogUtil.handleException("Ticking this tracker has been failed: " + name(), throwable);
+        }
+    }
+
+    /**
+     * Attempts to finish tracker quiescence by running any queued tasks and completing the drain receipt.
+     * <p>
+     * Attempts have no effect until {@link #quiesce} is set, so a reentrant close attempt from a close handler
+     * cannot complete the receipt before the original close requested quiescence. Attempts are ordered by this
+     * tracker's monitor, so an attempt either observes an updater still running ({@code ticking} is set by the
+     * updater before it checks the quiescence flag) and defers to the updater's own end-of-tick attempt, or
+     * observes no running updater and completes the receipt exactly once. Queued tasks run outside this
+     * tracker's monitor, so user tasks may call back into tracker methods without deadlock.
+     * </p>
+     *
+     * @since 3.4.2
+     */
+    private void quiesceAndComplete() {
+        if (drainFuture.isDone() || !quiesce.get()) return;
+        synchronized (this) {
+            if (ticking || drainingTasks) return;
+            drainingTasks = true;
+        }
+        Runnable task;
+        try {
+            while ((task = queuedTask.poll()) != null) task.run();
+        } catch (Throwable throwable) {
+            drainFuture.completeExceptionally(throwable);
+            LogUtil.handleException("Draining queued tracker tasks has been failed: " + name(), throwable);
+            return;
+        } finally {
+            synchronized (this) {
+                drainingTasks = false;
+            }
+        }
+        synchronized (this) {
+            if (ticking) return;
+            drainFuture.complete(null);
         }
     }
 
@@ -271,11 +327,15 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
 
     /**
      * Schedules a task to run on the next tracker tick.
+     * <p>
+     * Tasks queued after the tracker begins draining are invalidated and never run.
+     * </p>
      *
      * @param runnable the task to run
      * @since 1.15.2
      */
     public void task(@NotNull Runnable runnable) {
+        if (quiesce.get() || drainFuture.isDone()) return;
         queuedTask.add(Objects.requireNonNull(runnable));
     }
 
@@ -371,11 +431,60 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
 
     protected void close(@NotNull CloseReason reason) {
         if (isClosed.compareAndSet(false, true)) {
-            closeEventHandler.accept(this, reason);
-            shutdown();
-            pipeline.despawn();
-            LogUtil.debug(DebugConfig.DebugOption.TRACKER, () -> getClass().getSimpleName() + " closed: " + name());
+            try {
+                closeEventHandler.accept(this, reason);
+            } catch (Throwable throwable) {
+                drainFuture.completeExceptionally(throwable);
+                LogUtil.handleException("Closing tracker has been failed: " + name(), throwable);
+            } finally {
+                // Draining must let a running updater finish on its own; interrupting it could
+                // abort pipeline work mid-flight before the receipt completes.
+                shutdown(reason != CloseReason.DRAIN);
+                quiesce.set(true);
+                pipeline.despawn();
+                quiesceAndComplete();
+                LogUtil.debug(DebugConfig.DebugOption.TRACKER, () -> getClass().getSimpleName() + " closed: " + name());
+            }
+        } else {
+            quiesceAndComplete();
         }
+    }
+
+    /**
+     * Closes this tracker and returns a completion receipt that proves all tracker-originated work has ended.
+     * <p>
+     * The returned stage completes when the following postconditions hold:
+     * </p>
+     * <ol>
+     *   <li>no new tracker-originated source or pipeline work can begin;</li>
+     *   <li>scheduled recurrence has been cancelled;</li>
+     *   <li>any updater invocation already running has returned;</li>
+     *   <li>queued or deferred tracker work has either completed or been invalidated;</li>
+     *   <li>tracker-originated callbacks and tasks that could access the source have completed or been invalidated;</li>
+     *   <li>pipeline despawn and final close work has completed; and</li>
+     *   <li>after completion, no future tracker-originated access to the {@link RenderSource} occurs.</li>
+     * </ol>
+     * <p>
+     * After the stage completes, no future tracker-originated access to the {@link RenderSource} can occur.
+     * This call never blocks and is safe to invoke from the main server thread; a plugin that owns the source
+     * entity can join the returned stage (on an async scheduler) before removing the entity.
+     * </p>
+     *
+     * <pre>{@code
+     * tracker.closeAndDrain()
+     *     .thenRunAsync(() -> {
+     *         // safe: the tracker can no longer access the source
+     *         entity.remove();
+     *     });
+     * }</pre>
+     *
+     * @return a completion stage whose normal completion proves the drain postconditions above; it completes
+     *   exceptionally only if a queued task or close handler threw, and repeated calls return the same stage
+     * @since 3.4.2
+     */
+    public @NotNull CompletionStage<Void> closeAndDrain() {
+        close(CloseReason.DRAIN);
+        return drainFuture;
     }
 
     /**
@@ -1081,7 +1190,13 @@ public sealed abstract class Tracker implements AutoCloseable permits EntityTrac
          * The entity or tracker was despawned.
          * @since 1.15.2
          */
-        DESPAWN(true)
+        DESPAWN(true),
+        /**
+         * The tracker was closed through {@link Tracker#closeAndDrain()}, waiting for all
+         * tracker-originated work to end before its completion receipt finishes.
+         * @since 3.4.2
+         */
+        DRAIN(false)
         ;
         private final boolean save;
 

--- a/api/src/test/java/kr/toxicity/model/api/tracker/TrackerCloseAndDrainTest.java
+++ b/api/src/test/java/kr/toxicity/model/api/tracker/TrackerCloseAndDrainTest.java
@@ -1,0 +1,517 @@
+/*
+ * This source file is part of BetterModel.
+ * Copyright (c) 2026 toxicity188
+ * Licensed under the MIT License.
+ * See LICENSE.md file for full license text.
+ */
+
+package kr.toxicity.model.api.tracker;
+
+import kr.toxicity.model.api.BetterModel;
+import kr.toxicity.model.api.BetterModelConfig;
+import kr.toxicity.model.api.BetterModelEventBus;
+import kr.toxicity.model.api.BetterModelEvaluator;
+import kr.toxicity.model.api.BetterModelLogger;
+import kr.toxicity.model.api.BetterModelPlatform;
+import kr.toxicity.model.api.data.renderer.ModelRenderer;
+import kr.toxicity.model.api.event.ModelEvent;
+import kr.toxicity.model.api.event.ModelEventApplication;
+import kr.toxicity.model.api.event.ModelEventListener;
+import kr.toxicity.model.api.manager.Manager;
+import kr.toxicity.model.api.manager.ReloadInfo;
+import kr.toxicity.model.api.nms.ModAnimationBundler;
+import kr.toxicity.model.api.nms.NMS;
+import kr.toxicity.model.api.nms.PacketBundler;
+import kr.toxicity.model.api.pack.PackZipper;
+import kr.toxicity.model.api.platform.PlatformAdapter;
+import kr.toxicity.model.api.platform.PlatformLocation;
+import kr.toxicity.model.api.platform.PlatformWorld;
+import kr.toxicity.model.api.config.DebugConfig;
+import kr.toxicity.model.api.config.IndicatorConfig;
+import kr.toxicity.model.api.config.ModuleConfig;
+import kr.toxicity.model.api.config.PackConfig;
+import kr.toxicity.model.api.mount.MountController;
+import kr.toxicity.model.api.platform.PlatformItemStack;
+import kr.toxicity.model.api.scheduler.ModelScheduler;
+import kr.toxicity.model.api.scheduler.ModelTask;
+import kr.toxicity.model.api.version.MinecraftVersion;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.semver4j.Semver;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the {@link Tracker#closeAndDrain()} completion contract.
+ *
+ * @since 3.4.2
+ */
+class TrackerCloseAndDrainTest {
+
+    private static final AtomicBoolean PLATFORM_REGISTERED = new AtomicBoolean();
+    private static ModelRenderer renderer;
+
+    @BeforeAll
+    static void registerFakePlatform() {
+        if (PLATFORM_REGISTERED.compareAndSet(false, true)) {
+            BetterModel.register(new FakePlatform());
+        }
+        renderer = new ModelRenderer("drain-test", ModelRenderer.Type.GENERAL, new LinkedHashMap<>(), Map.of());
+    }
+
+    @Test
+    void drainCompletesImmediatelyWhenIdle() {
+        var tracker = renderer.create(location(), TrackerModifier.DEFAULT);
+        assertFalse(tracker.isScheduled());
+        var future = tracker.closeAndDrain();
+        assertCompletion(future);
+        assertTrue(tracker.isClosed());
+    }
+
+    @Test
+    void queuedTaskIsInvalidatedAfterDrain() {
+        var tracker = renderer.create(location(), TrackerModifier.DEFAULT);
+        var future = tracker.closeAndDrain();
+        assertCompletion(future);
+        var ran = new AtomicBoolean();
+        tracker.task(() -> ran.set(true));
+        assertFalse(ran.get(), "A task queued after the drain completed must never run.");
+    }
+
+    @Test
+    void queuedTaskRunsBeforeCompletion() {
+        var tracker = renderer.create(location(), TrackerModifier.DEFAULT);
+        var queuedRan = new AtomicBoolean();
+        tracker.task(() -> queuedRan.set(true));
+        var future = tracker.closeAndDrain();
+        assertCompletion(future);
+        assertTrue(queuedRan.get(), "Work queued before the drain must complete before the receipt.");
+    }
+
+    @Test
+    void runningUpdaterDefersCompletionAndSourceAccessOrdersBeforeIt() throws Exception {
+        var tracker = renderer.create(location(), TrackerModifier.DEFAULT);
+        tracker.forRemoval(true);
+        var ticks = new AtomicInteger();
+        var updaterStarted = new CountDownLatch(1);
+        var updaterMayReturn = new CountDownLatch(1);
+        var completed = new AtomicBoolean();
+        var accessSawCompleted = new AtomicBoolean();
+
+        tracker.tick((_, _) -> {
+            // The first tick is the synchronous one inside start(); only the scheduled
+            // updater must block so the drain races a genuinely running updater.
+            if (ticks.getAndIncrement() == 0) return;
+            updaterStarted.countDown();
+            try {
+                updaterMayReturn.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            tracker.location();
+            accessSawCompleted.set(completed.get());
+        });
+        startScheduler(tracker);
+        assertTrue(updaterStarted.await(5, TimeUnit.SECONDS), "The updater must start before the drain.");
+
+        var future = tracker.closeAndDrain();
+        assertFalse(future.toCompletableFuture().isDone(), "The receipt must stay incomplete while an updater is blocked.");
+        future.thenRun(() -> completed.set(true));
+
+        var concurrent = new CompletableFuture<CompletionStage<Void>>();
+        Thread.ofVirtual().start(() -> concurrent.complete(tracker.closeAndDrain()));
+        assertSame(future, concurrent.get(5, TimeUnit.SECONDS));
+        assertFalse(future.toCompletableFuture().isDone());
+
+        updaterMayReturn.countDown();
+        assertCompletion(future);
+        assertTrue(tracker.isClosed());
+        assertFalse(accessSawCompleted.get(), "The receipt must not complete before a running updater returned.");
+
+        var ran = new AtomicBoolean();
+        tracker.task(() -> ran.set(true));
+        assertFalse(ran.get(), "No tracker work may run after the receipt completes.");
+    }
+
+    @Test
+    void failingQueuedTaskCompletesTheReceiptExceptionally() throws Exception {
+        var tracker = renderer.create(location(), TrackerModifier.DEFAULT);
+        tracker.task(() -> {
+            throw new IllegalStateException("boom");
+        });
+        var future = tracker.closeAndDrain();
+        var error = assertThrows(ExecutionException.class, () -> future.toCompletableFuture().get(5, TimeUnit.SECONDS));
+        assertInstanceOf(IllegalStateException.class, error.getCause());
+        assertTrue(tracker.isClosed());
+    }
+
+    @Test
+    void failingCloseHandlerCompletesTheReceiptExceptionally() throws Exception {
+        var tracker = renderer.create(location(), TrackerModifier.DEFAULT);
+        tracker.handleCloseEvent((_, _) -> {
+            throw new IllegalStateException("boom");
+        });
+        var future = tracker.closeAndDrain();
+        var error = assertThrows(ExecutionException.class, () -> future.toCompletableFuture().get(5, TimeUnit.SECONDS));
+        assertInstanceOf(IllegalStateException.class, error.getCause());
+        assertTrue(tracker.isClosed());
+    }
+
+    @Test
+    void repeatedAndReentrantClosesAreIdempotent() {
+        var tracker = renderer.create(location(), TrackerModifier.DEFAULT);
+        var closeCalls = new AtomicInteger();
+        tracker.handleCloseEvent((_, _) -> {
+            closeCalls.incrementAndGet();
+            tracker.close();
+        });
+        var first = tracker.closeAndDrain();
+        var second = tracker.closeAndDrain();
+        assertCompletion(first);
+        assertSame(first, second, "Repeated drains must return the same completion stage.");
+        assertEquals(1, closeCalls.get(), "Close handlers must run exactly once.");
+    }
+
+    private static void startScheduler(@NotNull Tracker tracker) {
+        try {
+            var spawn = Tracker.class.getDeclaredMethod("start");
+            spawn.setAccessible(true);
+            spawn.invoke(tracker);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void assertCompletion(@NotNull CompletionStage<Void> stage) {
+        assertDoesNotThrow(() -> stage.toCompletableFuture().get(5, TimeUnit.SECONDS));
+    }
+
+    private static @NotNull PlatformLocation location() {
+        return new FakeLocation();
+    }
+
+    private static @Nullable Object proxyDefault(@NotNull Method method) {
+        var type = method.getReturnType();
+        if (type == boolean.class) return false;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        if (type == double.class) return 0D;
+        if (type.isInterface()) {
+            var loader = type.getClassLoader();
+            return java.lang.reflect.Proxy.newProxyInstance(
+                loader,
+                new Class<?>[]{type},
+                (_, m, _) -> proxyDefault(m)
+            );
+        }
+        return null;
+    }
+
+    private static final class FakeConfig implements BetterModelConfig {
+        @Override
+        public @NotNull DebugConfig debug() {
+            return new DebugConfig(Set.of());
+        }
+
+        @Override
+        public @NotNull IndicatorConfig indicator() {
+            return new IndicatorConfig(Set.of());
+        }
+
+        @Override
+        public @NotNull ModuleConfig module() {
+            return new ModuleConfig(false, false);
+        }
+
+        @Override
+        public @NotNull PackConfig pack() {
+            return new PackConfig(false);
+        }
+
+        @Override
+        public boolean metrics() { return false; }
+
+        @Override
+        public boolean sightTrace() { return false; }
+
+        @Override
+        public boolean mergeWithExternalResources() { return false; }
+
+        @Override
+        public @NotNull Supplier<PlatformItemStack> item() {
+            return () -> null;
+        }
+
+        @Override
+        public double maxSight() { return 0; }
+
+        @Override
+        public double minSight() { return 0; }
+
+        @Override
+        public @NotNull String namespace() { return "test"; }
+
+        @Override
+        public @NotNull PackType packType() { return PackType.NONE; }
+
+        @Override
+        public @NotNull String buildFolderLocation() { return "build"; }
+
+        @Override
+        public boolean followMobInvisibility() { return false; }
+
+        @Override
+        public boolean usePurpurAfk() { return false; }
+
+        @Override
+        public boolean versionCheck() { return false; }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public @NotNull MountController defaultMountController() {
+            return (MountController) java.lang.reflect.Proxy.newProxyInstance(
+                MountController.class.getClassLoader(),
+                new Class<?>[]{MountController.class},
+                (_, _, _) -> null
+            );
+        }
+
+        @Override
+        public int lerpFrameTime() { return 0; }
+
+        @Override
+        public boolean cancelPlayerModelInventory() { return false; }
+
+        @Override
+        public long playerHideDelay() { return 0; }
+
+        @Override
+        public int packetBundlingSize() { return 0; }
+
+        @Override
+        public boolean enableStrictLoading() { return false; }
+    }
+
+    private static final class FakeLocation implements PlatformLocation {
+        @Override
+        public @NotNull PlatformWorld world() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public double x() {
+            return 0;
+        }
+
+        @Override
+        public double y() {
+            return 0;
+        }
+
+        @Override
+        public double z() {
+            return 0;
+        }
+
+        @Override
+        public float pitch() {
+            return 0;
+        }
+
+        @Override
+        public float yaw() {
+            return 0;
+        }
+
+        @Override
+        public @NotNull PlatformLocation add(double x, double y, double z) {
+            return this;
+        }
+
+        @Override
+        public @Nullable ModelTask task(@NotNull Runnable runnable) {
+            return null;
+        }
+
+        @Override
+        public @Nullable ModelTask taskLater(long delay, @NotNull Runnable runnable) {
+            return null;
+        }
+
+        @Override
+        public @NotNull String toString() {
+            return "FakeLocation(0, 0, 0)";
+        }
+    }
+
+    private static final class FakePlatform implements BetterModelPlatform {
+
+        private static BetterModelLogger proxyLogger() {
+            return (BetterModelLogger) java.lang.reflect.Proxy.newProxyInstance(
+                BetterModelLogger.class.getClassLoader(),
+                new Class<?>[]{BetterModelLogger.class},
+                (_, _, _) -> null
+            );
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+
+        @Override
+        public @NotNull File dataFolder() {
+            return new File("build/tmp/drain-test");
+        }
+
+        @Override
+        public @NotNull JarType jarType() {
+            return JarType.PAPER;
+        }
+
+        @Override
+        public @NotNull ReloadResult reload(@NotNull ReloadInfo info) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isSnapshot() {
+            return false;
+        }
+
+        @Override
+        public @NotNull BetterModelConfig config() {
+            return new FakeConfig();
+        }
+
+        @Override
+        public @NotNull MinecraftVersion version() {
+            return MinecraftVersion.V26_2;
+        }
+
+        @Override
+        public @NotNull Semver semver() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @NotNull NMS nms() {
+            var loader = NMS.class.getClassLoader();
+            var noopBundler = (PacketBundler) java.lang.reflect.Proxy.newProxyInstance(
+                PacketBundler.class.getClassLoader(),
+                new Class<?>[]{PacketBundler.class},
+                (_, method, _) -> {
+                    var name = method.getName();
+                    if ("isEmpty".equals(name)) return true;
+                    if ("isNotEmpty".equals(name)) return false;
+                    return null;
+                }
+            );
+            var noopModBundler = (ModAnimationBundler) java.lang.reflect.Proxy.newProxyInstance(
+                ModAnimationBundler.class.getClassLoader(),
+                new Class<?>[]{ModAnimationBundler.class},
+                (_, _, _) -> null
+            );
+            return (NMS) java.lang.reflect.Proxy.newProxyInstance(
+                loader,
+                new Class<?>[]{NMS.class},
+                (_, method, _) -> {
+                    var name = method.getName();
+                    if ("createBundler".equals(name) || "createParallelBundler".equals(name)) return noopBundler;
+                    if ("createModAnimationBuilder".equals(name)) return noopModBundler;
+                    return proxyDefault(method);
+                }
+            );
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public @NotNull <T extends Manager> T manager(@NotNull Class<T> managerClass) {
+            return (T) java.lang.reflect.Proxy.newProxyInstance(
+                managerClass.getClassLoader(),
+                new Class<?>[]{managerClass},
+                (_, method, _) -> proxyDefault(method)
+            );
+        }
+
+        @Override
+        public @NotNull ModelScheduler scheduler() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @NotNull PlatformAdapter adapter() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addReloadStartHandler(@NotNull Consumer<PackZipper> consumer) {
+        }
+
+        @Override
+        public void addReloadEndHandler(@NotNull Consumer<ReloadResult> consumer) {
+        }
+
+        @Override
+        public @NotNull BetterModelLogger logger() {
+            return proxyLogger();
+        }
+
+        @Override
+        public @NotNull BetterModelEvaluator evaluator() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @NotNull BetterModelEventBus eventBus() {
+            return new BetterModelEventBus() {
+                @Override
+                public @NotNull <T extends ModelEvent> ModelEventListener subscribe(
+                    @NotNull ModelEventApplication application,
+                    @NotNull Class<T> eventClass,
+                    @NotNull Consumer<T> consumer
+                ) {
+                    return ModelEventListener.NONE;
+                }
+
+                @Override
+                public <T extends ModelEvent> @NotNull Result call(
+                    @NotNull Class<? extends T> eventClass,
+                    @NotNull Supplier<T> eventSupplier
+                ) {
+                    return Result.NO_EVENT_HANDLER;
+                }
+            };
+        }
+
+        @Override
+        public @Nullable InputStream getResource(@NotNull String path) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #417: a non-blocking completion receipt that proves a `Tracker` has fully drained before the plugin removes the owning entity.

`Tracker#closeAndDrain()` closes the tracker and returns a `CompletionStage<Void>` that completes only when **all** tracker-originated work has ended:

1. no new tracker-originated source or pipeline work can begin;
2. scheduled recurrence has been cancelled;
3. any updater invocation already running has returned;
4. queued or deferred tracker work has either completed or been invalidated;
5. tracker-originated callbacks and tasks that could access the source have completed or been invalidated;
6. pipeline despawn and final close work has completed; and
7. after completion, no future tracker-originated access to the source occurs.

It never blocks and is safe to call from the main server thread:

```java
tracker.closeAndDrain()
    .thenRunAsync(() -> {
        // safe: the tracker can no longer access the source
        entity.remove();
    });
```

## Impacted modules

- `api` (`kr.toxicity.model.api.tracker.Tracker`, `CloseReason.DRAIN`)
- `api` test source set (new: `TrackerCloseAndDrainTest` + JUnit test dependencies in `api/build.gradle.kts`)

## How it works

- A quiescence gate inside `tick()`: once draining is requested, the next completed updater invocation (including one already in flight) runs any still-queued tasks and completes the receipt exactly once.
- Completion attempts are ordered by the tracker monitor and the `ticking` flag is set *before* the quiescence check, so a close racing a running updater can never complete the receipt while the updater is still inside its handler (Dekker-style ordering).
- `close(CloseReason.DRAIN)` cancels the scheduler **without interrupting** the in-flight updater — interrupting could abort pipeline work mid-flight before the receipt completes. Legacy reasons (`REMOVE`, `DESPAWN`, `PLUGIN_DISABLE`) keep their previous interrupt semantics.
- `task(...)` rejects new work from the moment draining begins; tasks queued before the drain are flushed before completion or invalidated.
- `start()` now refuses to reschedule a closed tracker (a late `spawnPacketHandler` callback could previously restart the scheduler after close).
- `pipeline.despawn()` runs before the receipt completes, satisfying postcondition 6; the constructor's late skin-context callback is invalidated once the tracker closes, satisfying postcondition 5/7.
- If a queued task or close handler throws, the receipt completes exceptionally instead of hanging; repeated/reentrant calls return the same stage.

## Compatibility

- Purely additive public API (`closeAndDrain()`, `@since 3.4.2`, matching the repo's `@since` versioning convention). No existing signatures changed.
- `close()` and `shutdown()` keep the same interrupt/despawn semantics for all pre-existing reasons. One deliberate behavior change: a throwing close handler is now logged and still fully tears the tracker down (previously teardown was skipped and the exception propagated).

## Tests / checks run

- `TrackerCloseAndDrainTest` (7 tests, all green): immediate completion when idle; queued-task invalidation after drain; queued work runs before completion; latch-blocked updater defers the receipt until it returns; reentrant/idempotent closes; exceptional completion for failing queued tasks and close handlers.
- `:bettermodel-api:check` and `:bettermodel-api:checkLicenses` — pass.

---

*This contribution was prepared with AI assistance (Codebuff) and reviewed by a human before submission.*